### PR TITLE
refactor: Made proper positioning of custom rendered text

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -1,8 +1,13 @@
+## Tech Debt
+
+- Go through TODOs in the code
+
 ## Versions
 
 - Add support of 1.21.11
 - Publish on Modrinth
 - Make a version checker which announces new versions found on Modrinth
+- Will NEU prices API be available? Do I need to hop to another one?
 
 ## Settings
 
@@ -31,7 +36,6 @@ Death sound is not played. :c Probably because player's world is not loaded whil
 - Remove command hint from overlays, add buttons to sample overlays in /feeshMoveAllGuis
 - Check that it works fine after loading the module without coords file
 - Use Center alignment as default for some widgets
-- Make overlays rendered under TabList
 - Check if "0" key works for numpad in /feeshMoveAllGuis
 
 ## Sea creatures

--- a/src/main/java/com/github/sleepypanda/feesh/mixin/InGameHudMixin.java
+++ b/src/main/java/com/github/sleepypanda/feesh/mixin/InGameHudMixin.java
@@ -15,8 +15,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
 public class InGameHudMixin {
-    @Inject(method = "render", at = @At("TAIL"))
-    private void feesh$onRenderInGameHud(
+    // Lets to draw custom content UNDER TabList and the rest of the HUD.
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderPlayerList(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/client/render/RenderTickCounter;)V", shift = At.Shift.BEFORE))
+    private void feesh$onRenderInGameHudBeforePlayerList(
         DrawContext drawContext,
         RenderTickCounter renderTickCounter,
         CallbackInfo ci

--- a/src/main/kotlin/com/github/sleepypanda/feesh/events/GameRenderEvent.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/events/GameRenderEvent.kt
@@ -7,8 +7,8 @@ import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.RenderTickCounter
 
 /*
- * This event is triggered when the in-game HUD is rendered.
- * Custom drawings are rendered under the background when a GUI (e.g. Inventory) is opened.
+ * This event is triggered during in-game HUD render, right before TabList (Players list) is drawn.
+ * Use it to draw custom content UNDER TabList and the rest of the HUD.
  */
 data class GameRenderEvent(
     val drawContext: DrawContext,

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/gui/FeeshGui.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/gui/FeeshGui.kt
@@ -50,8 +50,8 @@ class FeeshGui {
 
     constructor() {
         registeredGuis.add(this)
-        EventBus.subscribe(GameRenderEvent::class, { event -> draw(event.drawContext, event.textRenderer, event.mcClient) })
-        EventBus.subscribe(ScreenAfterBackgroundRenderEvent::class, ::postDrawAfterBackground)
+        EventBus.subscribe(GameRenderEvent::class, { event -> onDraw(event.drawContext, event.textRenderer, event.mcClient) })
+        EventBus.subscribe(ScreenAfterBackgroundRenderEvent::class, ::onPostDrawAfterBackground)
     }
     
     fun getCoordsDataKey(): String = coordsDataKey
@@ -177,11 +177,16 @@ class FeeshGui {
         return this
     }
 
+    fun onDraw(drawContext: DrawContext, textRenderer: TextRenderer, mcClient: MinecraftClient) {
+        if (mcClient.currentScreen is InventoryScreen && isClickable) return
+        draw(drawContext, textRenderer, mcClient)
+    }
+
     fun draw(drawContext: DrawContext, textRenderer: TextRenderer, mcClient: MinecraftClient) {
         if (lines.isEmpty()) return
         if (!WorldUtils.isInSkyblock()) return
-        if (!condition()) return
         if (settingsKey != null && !settingsKey!!()) return
+        if (!condition()) return
         if (mcClient.currentScreen is MoveGuisScreen) return
 
         drawContext.matrices.pushMatrix()
@@ -216,7 +221,7 @@ class FeeshGui {
         drawContext.matrices.popMatrix()
     }
 
-    fun postDrawAfterBackground(event: ScreenAfterBackgroundRenderEvent) { // Draw in front of background but under Inventory GUI
+    fun onPostDrawAfterBackground(event: ScreenAfterBackgroundRenderEvent) { // Draw in front of background but under Inventory GUI
         if (!isClickable) return
         if (event.screen !is InventoryScreen) return
 


### PR DESCRIPTION
Resolved the issue where custom overlays were drawn on top of Chat and TabList HUD.

Now, if an overlay is clickable, it's rendered on top of dark background of Inventory HUD, but under Chat / TabList / other HUDs.