### PR TITLE
fix: Track drops while being in "safe" GUIs & Do not track items taken from pet item swapping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,8 @@ Released on: ???
 
 ## Bugfixes
 
-- Track drops in Fishing profit tracker while being in Inventory GUI
+- Track drops in Fishing profit tracker while being in Inventory and some other "safe" GUIs
+- Do not track items taken from pet item swapping GUI in Fishing profit tracker
 - Allow increase/decrease/delete max level pets in Fishing profit tracker
 - Get rid of ,0 when formatting prices
 - Most important bugfix ever (thanks to gegerik for reporting)

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -54,6 +54,7 @@ Support for 1.21.11.
 ## Alerts & chat
 
 - Reminder if user is fishing with wrong hook/sinker during events or in hotspots.
+- Alert if player attempts to be scammed by Kat by giving her Epic Megalodon.
 - Rare SC cocooned alert
 - Spooky festival event ending alert (to kill mobs before despawn)
 - Phoenix proc'ed alert / Phoenix back alert (same as Spirit Mask)

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -1,6 +1,6 @@
 ## Players feedback
 
-- Items counted after /gfs or extracting pet items
+- Items counted after /gfs
 - Hotspot is gone when too sinked in lava
 - while i was fishing in the crystal hollows i noticed that the mob cap alert wasnt working for it
   - [I checked and for me it was working]

--- a/src/main/kotlin/com/github/sleepypanda/feesh/constants/FishingProfitDrops.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/constants/FishingProfitDrops.kt
@@ -16,11 +16,14 @@ data class FishingProfitDropInfo(
     val npcPrice: Double?,
     val shouldAnnounceRareDrop: Boolean = false, // If the item should be announced as a rare drop in player's chat (for valuable drops which have no standart RARE DROP! message from Hypixel)
     val amountOfMagmaFish: Int? = null, // Amount of Magma Fish to exchange a Trophy Fish at Odger
-    val salvage: SalvageableItemInfo? = null // Item to salvage into essence items
+    val salvage: SalvageableItemInfo? = null, // Item to salvage into essence items
+    val categories: List<String> = listOf(), // Categories the item belongs to
 )
 
-class FishingProfitDrops {
+class FishingProfitDrops {  
     companion object {
+        const val PET_ITEM_CATEGORY = "Pet Item"
+
         val items = listOf(
             // Dyes
             
@@ -1068,18 +1071,21 @@ class FishingProfitDrops {
                 itemName = "Fishing Exp Boost (UNCOMMON)",
                 itemDisplayName = "${UNCOMMON}Fishing Exp Boost +30%",
                 npcPrice = null,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
             FishingProfitDropInfo(
                 itemId = "PET_ITEM_FISHING_SKILL_BOOST_RARE",
                 itemName = "Fishing Exp Boost (RARE)",
                 itemDisplayName = "${RARE}Fishing Exp Boost +40%",
                 npcPrice = null,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
             FishingProfitDropInfo(
                 itemId = "PET_ITEM_FISHING_SKILL_BOOST_EPIC",
                 itemName = "Fishing Exp Boost (EPIC)",
                 itemDisplayName = "${EPIC}Fishing Exp Boost +50%",
                 npcPrice = null,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
             FishingProfitDropInfo(
                 itemId = "WATER_HYDRA_HEAD",
@@ -1148,6 +1154,7 @@ class FishingProfitDrops {
                 itemName = "Edible Seaweed",
                 itemDisplayName = "${RARE}Edible Seaweed",
                 npcPrice = 50_000.0,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
             FishingProfitDropInfo(
                 itemId = "BLUE_RING",
@@ -1351,6 +1358,7 @@ class FishingProfitDrops {
                 itemDisplayName = "${EPIC}Foraging Exp Boost +50%",
                 npcPrice = null,
                 shouldAnnounceRareDrop = true,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
 
             // Crimson Isle
@@ -1416,6 +1424,7 @@ class FishingProfitDrops {
                 itemName = "Burnt Texts",
                 itemDisplayName = "${LEGENDARY}Burnt Texts",
                 npcPrice = 1_000_000.0,
+                categories = listOf(PET_ITEM_CATEGORY),
             ),
             FishingProfitDropInfo(
                 itemId = "CHAIN_END_TIMES",

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -658,8 +658,8 @@ object FishingProfitTracker {
 
         val currentInventory = getFishingProfitItemsInCurrentInventory()
 
-        // Allow being in Wardrobe or Armor GUI, because we often are in them when killing mobs and getting drops
-        if (GuiUtils.isInChest() && !GuiUtils.isInWardrobeOrEquipmentGui()) {
+        // Allow being in some GUIs, because we often are in them when killing mobs and getting drops
+        if (GuiUtils.isInChest() && !GuiUtils.isInNonStorageGui()) {
             previousInventory = currentInventory.toMutableMap()
             return
         }
@@ -775,10 +775,13 @@ object FishingProfitTracker {
         if (itemId.startsWith("MAGMA_FISH") && lastGuisClosed.lastOdgerGuiClosedAt != null &&
             now.time - lastGuisClosed.lastOdgerGuiClosedAt!!.time < 1000) return true // User probably just filleted trophy fish
 
+        if (dropInfo.categories.contains(FishingProfitDrops.PET_ITEM_CATEGORY) && lastGuisClosed.lastPetItemSwapGuiClosedAt != null && 
+            now.time - lastGuisClosed.lastPetItemSwapGuiClosedAt!!.time < 1000) return true
+
         if (lastGuisClosed.lastAuctionGuiClosedAt != null && now.time - lastGuisClosed.lastAuctionGuiClosedAt!!.time < 3_000) return true
 
         val lastKatUpgrade = GuiUtils.lastKatUpgrade
-        if (lastKatUpgrade.lastPetClaimedAt != null && now.time - lastKatUpgrade.lastPetClaimedAt!!.time < 7 * 1000) { // It takes some time for pet to appear in the inventory after claiming from Kat
+        if (lastKatUpgrade.lastPetClaimedAt != null && now.time - lastKatUpgrade.lastPetClaimedAt!!.time < 7_000) { // It takes some time for pet to appear in the inventory after claiming from Kat
             val katPetName = lastKatUpgrade.petName?.removeFormatting() ?: return false
             if (dropInfo.itemName.contains(katPetName)) return true
         }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/GuiUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/GuiUtils.kt
@@ -25,6 +25,7 @@ data class LastGuisClosed(
     var lastCraftGuiClosedAt: Date? = null,
     var lastStorageGuiClosedAt: Date? = null,
     var lastBazaarGuiClosedAt: Date? = null,
+    var lastPetItemSwapGuiClosedAt: Date? = null,
     var lastHotmGuiClosedAt: Date? = null
 )
 
@@ -73,6 +74,8 @@ object GuiUtils {
                 lastGuisClosed.lastStorageGuiClosedAt = now
             chestName.contains("Bazaar Orders") || chestName.contains("Order options") || chestName.contains("Instant Buy") ->
                 lastGuisClosed.lastBazaarGuiClosedAt = now
+            chestName == "Swap Pet Item" || chestName == "Remove Pet Item" -> 
+                lastGuisClosed.lastPetItemSwapGuiClosedAt = now
             chestName.contains("Heart of the Mountain") -> lastGuisClosed.lastHotmGuiClosedAt = now
         }
     }
@@ -122,9 +125,21 @@ object GuiUtils {
         return screen.getTitle().getString().removeFormatting()
     }
 
-    fun isInWardrobeOrEquipmentGui(): Boolean {
+    /*
+     * Check if the player is a GUI which is non-storage (you can't take items from it).
+     * This is used to check if to ignore inventory changes when in some GUI.
+     * @returns {Boolean}
+     */
+    fun isInNonStorageGui(): Boolean {
         val guiName = getCurrentChestName() ?: return false
-        return guiName.startsWith("Wardrobe") || guiName.startsWith("Your Equipment")
+        return guiName.startsWith("Wardrobe") || 
+            guiName.startsWith("Your Equipment") || 
+            guiName.startsWith("Abiphone") || 
+            guiName == "Slayer" || 
+            guiName == "Accessory Bag Thaumaturgy" ||
+            guiName == "Stats Tuning" ||
+            guiName == "Skyblock Menu" ||
+            guiName == "Calendar and Events"
     }
 
     fun isInSacksGui(): Boolean {


### PR DESCRIPTION
- Track drops in Fishing profit tracker while being in Inventory and some other "safe" GUIs
- Do not track items taken from pet item swapping GUI in Fishing profit tracker