### PR TITLE
feat: More precise % in Sea creatures tracker

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -1,7 +1,8 @@
 ## Players feedback
 
+- Option to not count double hook in sc/hour
 - Items counted after /gfs
-- Hotspot is gone when too sinked in lava
+- Hotspot is gone message when swapping server
 - while i was fishing in the crystal hollows i noticed that the mob cap alert wasnt working for it
   - [I checked and for me it was working]
 - Profit Tracker not paused after 5 minutes?

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
@@ -50,7 +50,7 @@ object SeaCreaturesTracker {
     private const val TICKS_PER_UPDATE = 20
 
     private var data = PersistentDataManager.feeshData.seaCreatures
-    private val decimalFormat = DecimalFormat("#.#")
+    private val decimalFormat = DecimalFormat("#.##")
     private var tickCounter = 0
     private val baseTitle = "${AQUA}${BOLD}Sea creatures tracker"
 


### PR DESCRIPTION
Show two decimals when displaying SC % and DH %.
Having one decimal was not clear enough, e.g. 0.2% jawbus rate could be 0.18% or 0.24%.