### PR TITLE
fix: Fixed log error after generating sounds.json

### DIFF
--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/CustomSoundsManager.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/CustomSoundsManager.kt
@@ -6,7 +6,6 @@ import com.github.sleepypanda.feesh.constants.SeaCreatures
 import com.github.sleepypanda.feesh.constants.Sounds
 import com.github.sleepypanda.feesh.utils.RegisterUtils
 import com.github.sleepypanda.feesh.utils.FileUtils
-import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.PlayerUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
 import com.google.gson.Gson
@@ -199,7 +198,7 @@ object CustomSoundsManager {
     private fun generateSoundsJsonFromFiles() {
         try {
             if (!resourcePackSoundsDir.exists()) {
-                ChatUtils.sendLocalChat("Resource pack sounds directory does not exist. Please create it and add your .ogg files to it.", true)
+                FeeshMod.LOGGER.info("[Feesh] Resource pack sounds directory does not exist. Please create it and add your .ogg files to it.", true)
                 return
             }
             
@@ -232,7 +231,7 @@ object CustomSoundsManager {
             resourcePackSoundsJsonFile.parentFile?.mkdirs()
             resourcePackSoundsJsonFile.writeText(json)
             
-            ChatUtils.sendLocalChat("Generated sounds.json with ${oggFiles.size} sound entries", true)
+            FeeshMod.LOGGER.info("[Feesh] Generated sounds.json with ${oggFiles.size} sound entries")
         } catch (e: Exception) {
             FeeshMod.LOGGER.error("[Feesh] Failed to generate sounds.json for custom user resource pack", e)
         }


### PR DESCRIPTION
[Render thread/ERROR]: [Feesh] Failed to generate sounds.json for custom user resource pack java.lang.NullPointerException: Cannot invoke "net.minecraft.class_329.method_1743()" because "com.github.sleepypanda.feesh.FeeshMod.mc.field_1705" is null
	at knot/com.github.sleepypanda.feesh.utils.ChatUtils.sendLocalChat(ChatUtils.kt:68) ~[Feesh-1.1.0-alpha+1.21.10-fabric.jar:?]
	at knot/com.github.sleepypanda.feesh.utils.data.CustomSoundsManager.generateSoundsJsonFromFiles(CustomSoundsManager.kt:235) ~[Feesh-1.1.0-alpha+1.21.10-fabric.jar:?]
	at knot/com.github.sleepypanda.feesh.utils.data.CustomSoundsManager.init(CustomSoundsManager.kt:57) ~[Feesh-1.1.0-alpha+1.21.10-fabric.jar:?]
	at knot/com.github.sleepypanda.feesh.FeeshMod.onInitialize(FeeshMod.kt:101) ~[Feesh-1.1.0-alpha+1.21.10-fabric.jar:?]
	at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405) [fabric-loader-0.18.1.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:52) [fabric-loader-0.18.1.jar:?]
	at knot/net.minecraft.class_310.<init>(class_310.java:483) [client-intermediary.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:234) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514) [fabric-loader-0.18.1.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) [fabric-loader-0.18.1.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.18.1.jar:?]