### PR TITLE
refactor: Hotspot found / hotspot gone alerts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,12 +19,14 @@ Released on: ???
 
 ## Bugfixes
 
-- Added guidance and log warning for custom sounds filename - MC rejects to play sounds when file name is not [a-z0-9-_]
+- Added guidance and log warnings for custom sounds filename - MC rejects to play sounds when file name is not [a-z0-9-_]
 - Track drops in Fishing profit tracker while being in Inventory and some other "safe" GUIs
 - Do not track items taken from pet item swapping GUI in Fishing profit tracker
 - Allow increase/decrease/delete max level pets in Fishing profit tracker
 - Get rid of ,0 when formatting prices
 - Fixed error in logs after generating sounds.json for custom sounds resource pack
+- Made bigger hotspot detection radius
+- Fixed (I hope) fake "hotspot is gone" alert when hotspot is still active
 - Most important bugfix ever (thanks to gegerik for reporting)
 
 ## Special thanks

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -6,15 +6,10 @@ Support for 1.21.11.
 
 ## Fishing profit tracker
 
-- Option to hide timer and coins/h for Total.
 - Propose compacting or selling items like raw fish going to the inventory (full sack).
-- Add confirmation for deleting items from the tracker.
-- Rare drop sound on expensive items added to sacks (e.g. Emperor's Skull).
 - Track Agatha tickets / Forest Essence on Galatea based on contest results.
 - Use drop # in the chat message based on current profit tracker.
-- Option to right align the tracker (and others too)
 - Option to render icons instead of item names
-- Option to decrease elapsed time in Fishing Profit Tracker (when user forgot to stop tracker being afk)
 - Track scavenged coins in Fishing Profit Tracker
 - Track Ice Essence drop from mobs in Fishing Profit Tracker
 - Track pet level progress in coins while it's not maxed
@@ -53,6 +48,7 @@ Support for 1.21.11.
 
 ## Alerts & chat
 
+- Troubled Bubble drop
 - Reminder if user is fishing with wrong hook/sinker during events or in hotspots.
 - Alert if player attempts to be scammed by Kat by giving her Epic Megalodon.
 - Rare SC cocooned alert

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -1,14 +1,11 @@
 ## Players feedback
 
 - Items counted after /gfs
-- Troubled bubble?
-- Hotspot is gone message when swapping server
 - while i was fishing in the crystal hollows i noticed that the mob cap alert wasnt working for it
   - [I checked and for me it was working]
 - Profit Tracker not paused after 5 minutes?
   - [I checked and for me it was paused]
 - 1.21.11 support
-- Keybinds periodically reset
 - Rendering section from CT
 - Settings are not saved after exiting the game, probably because user closes window using X button to exit
 
@@ -16,6 +13,7 @@
 
 - Go through TODOs in the code
 - Rework ticks counters across all overlays
+- Keybinds periodically reset, probably after MC crashes or turning off PC
 
 ## Versions
 

--- a/src/main/java/com/github/sleepypanda/feesh/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/github/sleepypanda/feesh/mixin/MinecraftClientMixin.java
@@ -2,15 +2,29 @@ package com.github.sleepypanda.feesh.mixin;
 
 import com.github.sleepypanda.feesh.events.EventBus;
 import com.github.sleepypanda.feesh.events.models.GuiOpenedEvent;
+import com.github.sleepypanda.feesh.events.models.WorldUnloadEvent;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.world.ClientWorld;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
-public class MinecraftClientMixin {
+public abstract class MinecraftClientMixin {
+    @Shadow
+    private ClientWorld world;
+
+    @Inject(method = "joinWorld", at = @At("HEAD"))
+    private void feesh$onWorldUnload(ClientWorld newWorld, CallbackInfo ci) {
+        if (this.world != null) {
+            EventBus.INSTANCE.publish(new WorldUnloadEvent());
+        }
+    }
+
     @Inject(method = "setScreen", at = @At("HEAD"))
     private void feesh$onScreenOpened(Screen screen, CallbackInfo ci) {
         if (screen != null) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/events/EventBus.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/events/EventBus.kt
@@ -7,6 +7,7 @@ import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.GameClosedEvent
 import com.github.sleepypanda.feesh.events.models.GameStartedEvent
 import com.github.sleepypanda.feesh.events.models.GuiClosedEvent
+import com.github.sleepypanda.feesh.events.models.ArmorStandDespawnedEvent
 import com.github.sleepypanda.feesh.events.models.ItemEntitySpawnedEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
 import kotlin.reflect.KClass
@@ -24,6 +25,7 @@ import net.minecraft.text.Text
 import net.minecraft.client.MinecraftClient
 import net.minecraft.world.World
 import net.minecraft.entity.ItemEntity
+import net.minecraft.entity.decoration.ArmorStandEntity
 
 object EventBus {
     private val subscribers = mutableMapOf<KClass<*>, MutableList<(Any) -> Unit>>()
@@ -84,6 +86,12 @@ object EventBus {
         ClientEntityEvents.ENTITY_LOAD.register { entity, _ ->
             if (entity is ItemEntity) {
                 publish(ItemEntitySpawnedEvent(entity))
+            }
+        }
+
+        ClientEntityEvents.ENTITY_UNLOAD.register { entity, _ ->
+            if (entity is ArmorStandEntity) {
+                publish(ArmorStandDespawnedEvent(entity))
             }
         }
     }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/events/models/ArmorStandDespawnedEvent.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/events/models/ArmorStandDespawnedEvent.kt
@@ -1,0 +1,11 @@
+package com.github.sleepypanda.feesh.events.models
+
+import net.minecraft.entity.decoration.ArmorStandEntity
+
+/**
+ * Event for when an Armor Stand is removed from the world (despawned/unloaded).
+ * @param armorStand The ArmorStandEntity that was removed.
+ */
+data class ArmorStandDespawnedEvent(
+    val armorStand: ArmorStandEntity
+)

--- a/src/main/kotlin/com/github/sleepypanda/feesh/events/models/WorldUnloadEvent.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/events/models/WorldUnloadEvent.kt
@@ -1,0 +1,6 @@
+package com.github.sleepypanda.feesh.events.models
+
+/**
+ * Called when the client world is about to be unloaded.
+ */
+class WorldUnloadEvent

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
@@ -47,14 +47,14 @@ object HotspotGoneAlert {
         if (!Alerts.alertOnHotspotGone || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
         if (lastClosestHotspot == null) return
         if (lastClosestHotspot!!.entity.uuid != event.armorStand.uuid) return
-        if (lastClosestHotspot!!.entity.customName?.string != "HOTSPOT") return
+        if (event.armorStand.customName?.string != "HOTSPOT") return
 
         val player = FeeshMod.mc.player ?: return
         val distance = EntityUtils.getDistance(player, lastClosestHotspot!!.entity)
         if (distance > HOTSPOT_CHECK_RANGE) return
 
-        lastClosestHotspot = null
         playAlert(lastClosestHotspot!!.perk)
+        lastClosestHotspot = null
     }
 
     private fun trackLatestHotspot() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
@@ -12,19 +12,21 @@ import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
 import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
+import com.github.sleepypanda.feesh.events.models.ArmorStandDespawnedEvent
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
-import net.minecraft.entity.projectile.FishingBobberEntity
 
 object HotspotGoneAlert {
     private var lastClosestHotspot: HotspotUtils.HotspotData? = null
     private var tickCounter = 0
     private const val TICKS_PER_CHECK = 10
-    private const val HOTSPOT_CHECK_RANGE = 20.0
+    private const val HOTSPOT_CHECK_RANGE = 30.0
+    private const val NEAREST_HOTSPOT_RANGE_FROM_HOOK = 5.0
 
     fun init() {
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
         EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
+        EventBus.subscribe(ArmorStandDespawnedEvent::class, ::onHotspotDespawned)
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
@@ -38,54 +40,40 @@ object HotspotGoneAlert {
         if (tickCounter < TICKS_PER_CHECK) return
         tickCounter = 0
 
-        playAlertOnHotspotGone()
+        trackLatestHotspot()
     }
 
-    private fun playAlertOnHotspotGone() {
+    private fun onHotspotDespawned(@Suppress("UNUSED_PARAMETER") event: ArmorStandDespawnedEvent) {
+        if (!Alerts.alertOnHotspotGone || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
+        if (lastClosestHotspot == null) return
+        if (lastClosestHotspot!!.entity.uuid != event.armorStand.uuid) return
+        if (lastClosestHotspot!!.entity.customName?.string != "HOTSPOT") return
+
+        val player = FeeshMod.mc.player ?: return
+        val distance = EntityUtils.getDistance(player, lastClosestHotspot!!.entity)
+        if (distance > HOTSPOT_CHECK_RANGE) return
+
+        lastClosestHotspot = null
+        playAlert(lastClosestHotspot!!.perk)
+    }
+
+    private fun trackLatestHotspot() {
         try {
             if (!Alerts.alertOnHotspotGone || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
 
             val player = FeeshMod.mc.player ?: return
-            val nearbyHotspots = HotspotUtils.findHotspotsInRange(player, HOTSPOT_CHECK_RANGE)
-
-            // If player moved away from the last hotspot, clear it
-            if (lastClosestHotspot != null) {
-                val distance = EntityUtils.getDistance(player, lastClosestHotspot!!.entity)
-                if (distance > HOTSPOT_CHECK_RANGE) {
-                    lastClosestHotspot = null
-                }
-            }
-
-            // Check if the last hotspot is gone
-            if (lastClosestHotspot != null) {
-                val distance = EntityUtils.getDistance(player, lastClosestHotspot!!.entity)
-                if (distance <= HOTSPOT_CHECK_RANGE) {
-                    val hotspotStillExists = nearbyHotspots.any { hotspot ->
-                        hotspot.x == lastClosestHotspot!!.x &&
-                        hotspot.y == lastClosestHotspot!!.y &&
-                        hotspot.z == lastClosestHotspot!!.z
-                    }
-
-                    if (!hotspotStillExists) {
-                        playAlert(lastClosestHotspot!!.perk)
-                        lastClosestHotspot = null
-                    }
-                }
-            }
-
-            // Update lastClosestHotspot if fishing hook is active
             val isHookActive = EntityUtils.isFishingHookActive(player)
-            if (isHookActive) {
-                val playerHook = EntityUtils.getPlayersFishingHook()
-                if (playerHook != null) {
-                    val closestHotspot = HotspotUtils.findClosestHotspotInRange(playerHook, HotspotUtils.HOTSPOT_RANGE)
-                    if (closestHotspot != null) {
-                        lastClosestHotspot = closestHotspot
-                    }
-                }
+            if (!isHookActive) return
+
+            val playerHook = EntityUtils.getPlayersFishingHook()
+            if (playerHook == null) return
+
+            val closestHotspot = HotspotUtils.findClosestHotspotInRange(playerHook, NEAREST_HOTSPOT_RANGE_FROM_HOOK)
+            if (closestHotspot != null) {
+                lastClosestHotspot = closestHotspot
             }
         } catch (e: Exception) {
-            FeeshMod.LOGGER.error("[Feesh] Failed to check if Hotspot is gone", e)
+            FeeshMod.LOGGER.error("[Feesh] Failed to track latest Hotspot", e)
         }
     }
 
@@ -95,4 +83,3 @@ object HotspotGoneAlert {
         SoundUtils.playSound()
     }
 }
-

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
@@ -14,7 +14,10 @@ import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ArmorStandDespawnedEvent
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
-import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
+import com.github.sleepypanda.feesh.events.models.WorldUnloadEvent
+import java.util.Timer
+import java.util.UUID
+import kotlin.concurrent.timerTask
 
 object HotspotGoneAlert {
     private var lastClosestHotspot: HotspotUtils.HotspotData? = null
@@ -25,11 +28,11 @@ object HotspotGoneAlert {
 
     fun init() {
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
-        EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
+        EventBus.subscribe(WorldUnloadEvent::class, ::onWorldChanged)
         EventBus.subscribe(ArmorStandDespawnedEvent::class, ::onHotspotDespawned)
     }
 
-    private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
+    private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldUnloadEvent) {
         lastClosestHotspot = null
     }
 
@@ -45,16 +48,25 @@ object HotspotGoneAlert {
 
     private fun onHotspotDespawned(@Suppress("UNUSED_PARAMETER") event: ArmorStandDespawnedEvent) {
         if (!Alerts.alertOnHotspotGone || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
-        if (lastClosestHotspot == null) return
-        if (lastClosestHotspot!!.entity.uuid != event.armorStand.uuid) return
+        val hotspot = lastClosestHotspot ?: return
+        if (hotspot.entity.uuid != event.armorStand.uuid) return
         if (event.armorStand.customName?.string != "HOTSPOT") return
 
         val player = FeeshMod.mc.player ?: return
-        val distance = EntityUtils.getDistance(player, lastClosestHotspot!!.entity)
+        val distance = EntityUtils.getDistance(player, hotspot.entity)
         if (distance > HOTSPOT_CHECK_RANGE) return
 
-        playAlert(lastClosestHotspot!!.perk)
-        lastClosestHotspot = null
+        val perk = hotspot.perk
+        val hotspotUuid: UUID = event.armorStand.uuid
+
+        Timer().schedule(timerTask {
+            FeeshMod.mc.execute {
+                if (lastClosestHotspot == null) return@execute
+                if (lastClosestHotspot!!.entity.uuid != hotspotUuid) return@execute
+                playAlert(perk)
+                lastClosestHotspot = null
+            }
+        }, 100) // If player changes server, it causes armor stand to despawn before, but we don't need alert. Let onWorldChanged trigger first.
     }
 
     private fun trackLatestHotspot() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
@@ -9,6 +9,7 @@ import com.github.sleepypanda.feesh.utils.PlayerUtils
 import com.github.sleepypanda.feesh.utils.HotspotUtils
 import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
+import com.github.sleepypanda.feesh.utils.EntityUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
 import com.github.sleepypanda.feesh.utils.KeybindUtils
 import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
@@ -16,6 +17,7 @@ import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
+import com.github.sleepypanda.feesh.events.models.ArmorStandDespawnedEvent
 import java.util.UUID
 import net.minecraft.text.Text
 import net.minecraft.text.Style
@@ -27,7 +29,7 @@ import org.lwjgl.glfw.GLFW
 
 object HotspotFoundMessage {
     private var lastClosestHotspot: HotspotUtils.HotspotData? = null
-    private var lastFoundHotspotIds = mutableListOf<UUID>()
+    private var lastFoundHotspotIds = mutableListOf<UUID>() // Last 2 found hotspots' uuid, to not alert again and again when moving between 2 close hotspots
     private var tickCounter = 0
     private const val TICKS_PER_CHECK = 10
     private const val NEAREST_HOTSPOT_RANGE_FROM_PLAYER = 10.0
@@ -37,6 +39,7 @@ object HotspotFoundMessage {
 
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
         EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
+        EventBus.subscribe(ArmorStandDespawnedEvent::class, ::onHotspotDespawned)
     }
 
     private fun registerKeybinds() {
@@ -65,6 +68,23 @@ object HotspotFoundMessage {
         sendMessageOnHotspotFound()
     }
 
+    private fun onHotspotDespawned(@Suppress("UNUSED_PARAMETER") event: ArmorStandDespawnedEvent) {
+        if (!Chat.messageOnHotspotFound && !Chat.autoMessageOnHotspotFound) return
+        if (!WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
+
+        val hotspotId = event.armorStand.uuid
+        if (!lastFoundHotspotIds.contains(hotspotId) && lastClosestHotspot?.entity?.uuid != hotspotId) return
+
+        val player = FeeshMod.mc.player ?: return
+        val distance = EntityUtils.getDistance(player, event.armorStand)
+        if (distance > 30.0) return // Probably user just moved away so the nametag is not rendered anymore
+
+        lastFoundHotspotIds.remove(hotspotId)
+        if (lastClosestHotspot != null && lastClosestHotspot!!.entity.uuid == hotspotId) {
+            lastClosestHotspot = null
+        }
+    }
+
     private fun sendMessageWithNearestHotspot(isParty: Boolean) {
         try {
             if (!WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld()) return
@@ -84,23 +104,16 @@ object HotspotFoundMessage {
 
     private fun sendMessageOnHotspotFound() {
         try {
-            if ((!Chat.messageOnHotspotFound && !Chat.autoMessageOnHotspotFound) || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
+            if (!Chat.messageOnHotspotFound && !Chat.autoMessageOnHotspotFound) return
+            if (!WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
 
             val player = FeeshMod.mc.player ?: return
-            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player, NEAREST_HOTSPOT_RANGE_FROM_PLAYER)
-            val closestHotspotId = closestHotspot?.entity?.uuid
+            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player, NEAREST_HOTSPOT_RANGE_FROM_PLAYER) ?: return
+            val closestHotspotId = closestHotspot.entity.uuid
 
-            if (closestHotspot != null && 
-                closestHotspotId != null &&
-                !lastFoundHotspotIds.contains(closestHotspotId) && (
-                    lastClosestHotspot == null ||
-                    (lastClosestHotspot != null && !(
-                        closestHotspot.x == lastClosestHotspot!!.x &&
-                        closestHotspot.y == lastClosestHotspot!!.y &&
-                        closestHotspot.z == lastClosestHotspot!!.z
-                    ))
-                )
-            ) {
+            if (lastFoundHotspotIds.contains(closestHotspotId)) return
+
+            if (lastClosestHotspot == null || (closestHotspot.entity.uuid != lastClosestHotspot!!.entity.uuid)) {
                 announceFoundHotspot(closestHotspot.x, closestHotspot.y, closestHotspot.z, closestHotspot.perk)
 
                 lastFoundHotspotIds.add(0, closestHotspotId)
@@ -109,9 +122,7 @@ object HotspotFoundMessage {
                 }
             }
 
-            if (closestHotspot != null) {
-                lastClosestHotspot = closestHotspot
-            }
+            lastClosestHotspot = closestHotspot
         } catch (e: Exception) {
             FeeshMod.LOGGER.error("[Feesh] Failed to send message on Hotspot found.", e)
         }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
@@ -17,14 +17,12 @@ import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
 import java.util.UUID
-import kotlin.random.Random
 import net.minecraft.text.Text
 import net.minecraft.text.Style
 import net.minecraft.text.ClickEvent
 import net.minecraft.text.HoverEvent
 import net.minecraft.text.ClickEvent.RunCommand
 import net.minecraft.text.HoverEvent.ShowText
-import net.minecraft.client.option.KeyBinding
 import org.lwjgl.glfw.GLFW
 
 object HotspotFoundMessage {
@@ -32,6 +30,7 @@ object HotspotFoundMessage {
     private var lastFoundHotspotIds = mutableListOf<UUID>()
     private var tickCounter = 0
     private const val TICKS_PER_CHECK = 10
+    private const val NEAREST_HOTSPOT_RANGE_FROM_PLAYER = 10.0
 
     fun init() {
         registerKeybinds()
@@ -71,12 +70,12 @@ object HotspotFoundMessage {
             if (!WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld()) return
 
             val player = FeeshMod.mc.player ?: return
-            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player)
+            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player, NEAREST_HOTSPOT_RANGE_FROM_PLAYER)
             
             if (closestHotspot != null) {
                 announceNearestHotspot(closestHotspot.x, closestHotspot.y, closestHotspot.z, closestHotspot.perk, isParty)
             } else {
-                ChatUtils.sendLocalChat("${WHITE}No Hotspot found nearby, move closer to be in ${HotspotUtils.HOTSPOT_RANGE.toInt()} blocks range!", true)
+                ChatUtils.sendLocalChat("${WHITE}No Hotspot found nearby, move closer to be in ${NEAREST_HOTSPOT_RANGE_FROM_PLAYER.toInt()} blocks range!", true)
             }
         } catch (e: Exception) {
             FeeshMod.LOGGER.error("[Feesh] Failed to share nearby Hotspot.", e)
@@ -88,7 +87,7 @@ object HotspotFoundMessage {
             if ((!Chat.messageOnHotspotFound && !Chat.autoMessageOnHotspotFound) || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
 
             val player = FeeshMod.mc.player ?: return
-            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player)
+            val closestHotspot = HotspotUtils.findClosestHotspotInRange(player, NEAREST_HOTSPOT_RANGE_FROM_PLAYER)
             val closestHotspotId = closestHotspot?.entity?.uuid
 
             if (closestHotspot != null && 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/HotspotUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/HotspotUtils.kt
@@ -16,8 +16,6 @@ object HotspotUtils {
         val perk: String?
     )
 
-    const val HOTSPOT_RANGE = 7.0
-
     /**
      * Check if an armor stand is a perk for a hotspot armor stand.
      * A perk armor stand must be at the same X and Z, Y is below the HOTSPOT, within 1 block, and have the same pitch.
@@ -39,7 +37,7 @@ object HotspotUtils {
      * @param distance The maximum distance to search.
      * @returns HotspotData in the format { entity, position, perk } or null if not found.
      */
-    fun findClosestHotspotInRange(entity: Entity, distance: Double = HOTSPOT_RANGE): HotspotData? {
+    fun findClosestHotspotInRange(entity: Entity, distance: Double): HotspotData? {
         val armorStands = EntityUtils.getArmorStandsInRange(entity, distance)
         if (armorStands.isEmpty()) return null
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/PlayerUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/PlayerUtils.kt
@@ -151,7 +151,7 @@ object PlayerUtils {
             cachedLastFishingHookSeenAt = Date()
 
             val playerHook = EntityUtils.getPlayersFishingHook() ?: return
-	        HotspotUtils.findClosestHotspotInRange(playerHook) ?: return
+	        HotspotUtils.findClosestHotspotInRange(playerHook, 5.0) ?: return
 	        cachedLastFishingHookInHotspotSeenAt = Date()
         }
     }


### PR DESCRIPTION
- Made bigger hotspot detection radius
- Fixed (I hope) fake "hotspot is gone" alert when hotspot is still active
- "Hotspot gone" now relies on armor stand despawn event rather than periodic nearby armor stands detection