### PR TITLE
refactor: Update Gradle configuration to force Kotlin version & disable parallel builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,12 @@ plugins {
     id("dev.deftu.gradle.tools.minecraft.releases") // Applies the Minecraft auto-releasing plugin, which allows you to automatically release your mod to CurseForge and Modrinth.
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-stdlib:2.2.21")
+    }
+}
+
 repositories {
     maven("https://repo.essential.gg/repository/maven-public")
     maven("https://maven.teamresourceful.com/repository/maven-public/")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal
 
 # Gradle configuration
 org.gradle.jvmargs=-Xms1m -Xmx4g -XX:+UnlockExperimentalVMOptions -XX:SoftMaxHeapSize=2g -XX:+UseStringDeduplication -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
-org.gradle.parallel=true
+org.gradle.parallel=false
 
 kotlin.daemon.jvmargs=-Xmx2g
 


### PR DESCRIPTION
Update Gradle configuration to force Kotlin version - so the Kotlin extension stops failing due to some files built using Kotlin 2.3.0.
Disable parallel builds execution - to try avoiding cache lock errors I receive all the time.