### PR TITLE
fix: Fixed slot text not being rendered when in NPC menu (e.g. Booster Cookie)

### DIFF
--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/AutoRecombFlag.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/AutoRecombFlag.kt
@@ -1,6 +1,7 @@
 package com.github.sleepypanda.feesh.features.items.slottext
 
 import com.github.sleepypanda.feesh.settings.categories.Items
+import com.github.sleepypanda.feesh.utils.ChatUtils.getFormattedString
 import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
 import com.github.sleepypanda.feesh.utils.ItemUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
@@ -23,7 +24,8 @@ object AutoRecombFlag : BaseSlotTextRenderer() {
 
     override fun getItemStackSlotText(stack: ItemStack, screen: HandledScreen<*>, slot: Slot): String? {
         if (stack.isEmpty()) return null
-        val name = stack.name.string.removeFormatting() ?: return null
+        val name = ItemUtils.getCleanItemName(stack.name.getFormattedString())
+        if (name.isNullOrEmpty()) return null
 
         val isFishingItem =
             name == "Slug Boots" ||

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/MobyDuckProgress.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/MobyDuckProgress.kt
@@ -2,6 +2,7 @@ package com.github.sleepypanda.feesh.features.items.slottext
 
 import com.github.sleepypanda.feesh.settings.categories.Items
 import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
+import com.github.sleepypanda.feesh.utils.ChatUtils.getFormattedString
 import com.github.sleepypanda.feesh.utils.ItemUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
 import net.minecraft.client.gui.screen.ingame.HandledScreen
@@ -24,7 +25,8 @@ object MobyDuckProgress : BaseSlotTextRenderer() {
 
     override fun getItemStackSlotText(stack: ItemStack, screen: HandledScreen<*>, slot: Slot): String? {
         if (stack.isEmpty()) return null
-        if (stack.name.string.removeFormatting() != "Moby-Duck") return null
+        val name = ItemUtils.getCleanItemName(stack.name.getFormattedString())
+        if (name != "Moby-Duck") return null
 
         val nbt = ItemUtils.getCustomData(stack) ?: return null
         val obj = ItemUtils.customDataToJsonObject(nbt) ?: return null

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/ThunderBottleProgress.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/items/slottext/ThunderBottleProgress.kt
@@ -2,6 +2,7 @@ package com.github.sleepypanda.feesh.features.items.slottext
 
 import com.github.sleepypanda.feesh.settings.categories.Items
 import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
+import com.github.sleepypanda.feesh.utils.ChatUtils.getFormattedString
 import com.github.sleepypanda.feesh.utils.ItemUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
 import net.minecraft.client.gui.screen.ingame.HandledScreen
@@ -31,7 +32,7 @@ object ThunderBottleProgress : BaseSlotTextRenderer() {
 
     override fun getItemStackSlotText(stack: ItemStack, screen: HandledScreen<*>, slot: Slot): String? {
         if (stack.isEmpty()) return null
-        val name = stack.name.string.removeFormatting() ?: return null
+        val name = ItemUtils.getCleanItemName(stack.name.getFormattedString())
 
         if (!BOTTLES.map { it.name }.contains(name)) return null
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -668,7 +668,7 @@ object FishingProfitTracker {
         for (i in 0..35) {
             val stack = player.inventory.getStack(i)
             if (stack.isEmpty) continue
-            var slotItemName = getCleanItemName(stack.name.getFormattedString())
+            var slotItemName = ItemUtils.getCleanItemName(stack.name.getFormattedString())
             if (slotItemName.isBlank()) continue
 
             if (slotItemName == "Enchanted Book") {
@@ -709,15 +709,6 @@ object FishingProfitTracker {
             }
         }
         return result
-    }
-
-    private fun getCleanItemName(itemName: String): String {
-        if (itemName.isBlank()) return ""
-        var s = itemName
-        if (Regex(".+ §8x\\d+$").matches(s)) { // Booster cookie menu or NPCs append the amount to the item name - e.g. §9Fish Affinity Talisman §8x1
-            s = s.split(" ").dropLast(1).joinToString(" ")
-        }
-        return s.removeFormatting()
     }
 
     private fun getFishingProfitItemByName(itemName: String): FishingProfitDropInfo? {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
@@ -51,6 +51,20 @@ object ItemUtils {
     }
 
     /*
+     * Gets the clean item name without formatting. It also removes the amount suffix from NPC menu if present (e.g. §9Fish Affinity Talisman §8x1 -> Fish Affinity Talisman).
+     * @param itemName The formatted item name to clean.
+     * @returns {String} The clean item name.
+     */
+    fun getCleanItemName(itemName: String): String {
+        if (itemName.isBlank()) return ""
+        var s = itemName
+        if (Regex(".+ §8x\\d+$").matches(s)) { // Booster cookie menu or NPCs append the amount to the item name - e.g. §9Fish Affinity Talisman §8x1
+            s = s.split(" ").dropLast(1).joinToString(" ")
+        }
+        return s.removeFormatting()
+    }
+
+    /*
      * Checks if the item is a Dirt Rod.
      * @param item The item to check.
      * @returns {Boolean} True if the item is a Dirt Rod, false otherwise.


### PR DESCRIPTION
Booster cookie menu or NPCs append the amount to the item name - e.g. `§9Fish Affinity Talisman §8x1`