### PR TITLE
feat: Remove epic baby yeti from Kat highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This mod requires [Fabric API](https://modrinth.com/mod/fabric-api) and [Fabric 
 ## Items
 
 - **Trash enchanted books** — Highlights slots containing trash enchanted books flooding your inventory while fishing. Helps quickly find books to throw away or insta-sell.
-- **Wrong pets offered to Kat** — Highlights Kat's GUI slot when potentially wrong pets (e.g. Epic Megalodon, Epic Baby Yeti) are offered by mistake.
+- **Wrong pets offered to Kat** — Highlights Kat's GUI slot when potentially wrong pets (e.g. Epic Megalodon) are offered by mistake.
 - **Thunder Bottle charge progress** — Renders Thunder / Storm / Hurricane Bottle charge percentage in the item slot.
 - **Moby-Duck progress** — Renders Moby-Duck evolving percentage in the item slot.
 - **Auto-recomb flag** — Renders recomb upgrade flag (`R`) for auto-recombobulated fishing drops in the item slot.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ Released on: ???
 - Renamed Legion & Bobbin' Time tracker and its settings, to fit new purpose of showing various entity counters. **Please re-enable in settings if you used it!**
 - Added "Items" settings section with the following functionalities [all disabled by default]:
   - Highlight slots with trash enchanted books. Book names are configurable. You can use it to quickly find books to throw away or insta sell.
-  - Highlight Kat GUI slot with red color if you try to give her Epic Megalodon or Epic Baby Yeti. _For those who sometimes puts pets into Kat instead of George by mistake c:_
+  - Highlight Kat GUI slot with red color if you try to give her Epic Megalodon. _For those who sometimes puts pets into Kat instead of George by mistake c:_
   - Render percentage of Thunder / Storm / Hurricane Bottle charge progress in the item slot.
   - Render percentage of Moby-Duck evolving progress in the item slot.
   - Render recomb upgrade flag (R) for auto-recombobulated fishing drops in the item slot.

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -1,7 +1,7 @@
 ## Players feedback
 
 - TODO: Test in 1.21
-- Ragnarok timer for immunity - when it goes below 50% hp (e.g. 62.4). Max HP is 125 mil. Around 12seconds immunity?
+- Ragnarok timer for immunity - when it goes below 50% hp (e.g. 62.4). Max HP is 125 mil, or 250 on Derpy. Around 12 seconds immunity?
 - Someone has no Vial title/sound
 - Fished coins to add via the command.
 - Carmine dye into tracker
@@ -18,6 +18,7 @@
 - Keybinds periodically reset, probably after MC crashes or turning off PC
 - Version check to correctly detect newer version on Modrinth (e.g. 1.1.0 and 1.1.0-beta)
 - Will NEU prices API be available? Do I need to hop to another one?
+- Enabled highlighters / slot renderers to update dynamically instead of check every render event.
 
 ## Settings
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/items/background/KatWrongPetsHighlighter.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/items/background/KatWrongPetsHighlighter.kt
@@ -17,7 +17,6 @@ object KatWrongPetsHighlighter : BaseBackgroundHighlighter() {
     private const val CONFIRM_SLOT_INDEX = 22
     private const val KAT_HIGHLIGHT_COLOR = 0x80FF0000.toInt()
     private val MEGALODON_ITEM_NAME = "${EPIC}Megalodon"
-    private val BABY_YETI_ITEM_NAME = "${EPIC}Baby Yeti"
 
     override val highlightColor: Int = KAT_HIGHLIGHT_COLOR
 
@@ -37,15 +36,14 @@ object KatWrongPetsHighlighter : BaseBackgroundHighlighter() {
 
         if (slot.index == PET_SLOT_INDEX) {
             val itemName = stack.name.getFormattedString()
-            if (itemName.contains(MEGALODON_ITEM_NAME) || itemName.contains(BABY_YETI_ITEM_NAME)) return highlightColor
+            if (itemName.contains(MEGALODON_ITEM_NAME)) return highlightColor
             return null
         } else if (slot.index == CONFIRM_SLOT_INDEX) {
             if (itemColorCache.isEmpty()) return null
             val itemLore = stack.get(DataComponentTypes.LORE)?.lines?.map { it.getFormattedString() } ?: emptyList()
-            if (itemLore.any { it.contains(BABY_YETI_ITEM_NAME) || it.contains(MEGALODON_ITEM_NAME) }) return highlightColor
+            if (itemLore.any { it.contains(MEGALODON_ITEM_NAME) }) return highlightColor
             return null
         }
-        // TODO enabled highlighters to update dynamically instead of check every render event
 
         return null
     }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Items.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Items.kt
@@ -35,7 +35,7 @@ object Items : CategoryKt("Items") {
     var katWrongPetsHighlighter by boolean(false) {
         this.name = Translated("Wrong pets offered to Kat")
         this.description = Translated(
-            "${GRAY}Highlights Kat's GUI slot when you offer Kat some pets (Epic Megalodon, Epic Baby Yeti) potentially by mistake. ${DARK_GRAY}For those who regularly gets scammed by Kat, giving her Megalodons instead of George (that's me)."
+            "${GRAY}Highlights Kat's GUI slot when you offer Kat some pets (Epic Megalodon) potentially by mistake. ${DARK_GRAY}For those who regularly gets scammed by Kat, giving her Megalodons instead of George (that's me)."
         )
     }
 


### PR DESCRIPTION
As baby yeti will not drop as epic from the next SB update, so that it's not relevant