### PR TITLE
feat: Removed limitation of 30 blocks for seeing Reindrake HP

### DIFF
--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreatureHpTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreatureHpTracker.kt
@@ -245,7 +245,7 @@ object SeaCreatureHpTracker {
 
         return entities
             .filter { entity ->
-                EntityUtils.getDistance(player, entity) <= distance
+                EntityUtils.getDistance(player, entity) <= distance || entity.customName?.string?.contains("Reindrake") == true
             }
             .mapNotNull { entity ->
                 EntityUtils.parseSeaCreatureNametag(entity, includedSeaCreatureNames)


### PR DESCRIPTION
Reindrake flies high usually, so in most of cases 30 blocks limitation does not let you see its HP when you kill it normally. Anyway, server removes armor stand nametags if they are too far.