### PR TITLE
refactor: Debounce data.json file saving

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ Released on: ???
 
 - Track Agatha Contest results even if Fishing profit tracker is paused, while it's visible.
 
+## Other
+
+- Refactored data saving logic to debounce file writes. This accumulates data changes and saves them once over time, to avoid writing to the file too often.
+
 # 1.4.0
 
 Released on: 2026-03-31

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -17,33 +17,6 @@ FeeshMod.LOGGER.info("Nessie destination alert: ${mobEntity.x}, ${mobEntity.y}, 
 - Settings are not saved after exiting the game, probably because user closes window using X button to exit
 - On 1.21.11, original fishing timer armorstand appears for a second when the fish starts swimming towards bobber
 
-[Feesh] Error occurred in LinkedHashMap.java:1023 in method nextNode - Failed to save Feesh data data
-java.util.ConcurrentModificationException: null
-	at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1023) ~[?:?]
-	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1058) ~[?:?]
-	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1055) ~[?:?]
-	at knot/com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:220) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:154) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.Gson.toJson(Gson.java:944) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.Gson.toJson(Gson.java:899) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.Gson.toJson(Gson.java:848) ~[gson-2.11.0.jar:?]
-	at knot/com.google.gson.Gson.toJson(Gson.java:825) ~[gson-2.11.0.jar:?]
-	at knot/com.github.sleepypanda.feesh.utils.FileUtils.saveJsonToFileSync(FileUtils.kt:65) ~[Feesh-1.5.0-alpha+1.21.10-fabric.jar:?]
-	at knot/com.github.sleepypanda.feesh.utils.FileUtils.saveJsonToFileAsync$lambda$0(FileUtils.kt:95) ~[Feesh-1.5.0-alpha+1.21.10-fabric.jar:?]
-	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
-	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
-	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
-	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
-
 ## Tech Debt
 
 - Go through TODOs in the code

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareDropMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareDropMessage.kt
@@ -27,9 +27,9 @@ object RareDropMessage {
         EventBus.subscribe(RareDropEvent::class, ::onDrop)
     }
 
-    fun reset() {
+    fun reset(force: Boolean = false) {
         PersistentDataManager.feeshData.rareDropNotifications.items.clear()
-        saveData()
+        saveData(force)
     }
 
     private fun onDrop(event: RareDropEvent) {
@@ -75,7 +75,11 @@ object RareDropMessage {
         return "--> ${article} ${itemName} has dropped${metadataString} <--"
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/ArchfiendDiceProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/ArchfiendDiceProfitTracker.kt
@@ -150,7 +150,7 @@ object ArchfiendDiceProfitTracker {
         if (Overlays.resetArchfiendDiceProfitTrackerSessionOnGameClosed &&
             Overlays.archfiendDiceProfitTrackerOverlay &&
             (data.session.archfiend.rollsCount > 0 || data.session.highClass.rollsCount > 0)) {
-            resetSession()
+            resetSession(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Archfiend Dice profit tracker [Session] on game closed.")
         }
     }
@@ -185,9 +185,9 @@ object ArchfiendDiceProfitTracker {
         }
     }
 
-    private fun resetSession() {
+    private fun resetSession(force: Boolean = false) {
         data.session = ArchfiendDiceData()
-        saveData()
+        saveData(force)
     }
 
     private fun resetTotal() {
@@ -361,7 +361,11 @@ object ArchfiendDiceProfitTracker {
         return lastDiceRolledAt != null && Date().time - lastDiceRolledAt!!.time < 60_000
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BayouTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BayouTracker.kt
@@ -139,15 +139,15 @@ object BayouTracker {
             Overlays.bayouTrackerOverlay &&
             hasData()
         ) {
-            reset()
+            reset(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Bayou tracker on game closed.")
         }
     }
 
-    private fun reset() {
+    private fun reset(force: Boolean = false) {
         data.titanoboa.reset()
         data.titanoboaSheds.reset()
-        saveData()
+        saveData(force)
     }
 
     private fun resetBayouTracker(isConfirmed: Boolean) {
@@ -167,8 +167,12 @@ object BayouTracker {
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 
     fun setTitanoboaSheds(count: Int, lastOn: Date?) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/CrimsonIsleTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/CrimsonIsleTracker.kt
@@ -264,19 +264,19 @@ object CrimsonIsleTracker {
         if (Overlays.resetCrimsonIsleTrackerOnGameClosed &&
             Overlays.crimsonIsleTrackerOverlay &&
             hasData()) {
-            reset()
+            reset(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Crimson Isle tracker on game closed.")
         }
     }
 
-    private fun reset() {
+    private fun reset(force: Boolean = false) {
         data.thunder.reset()
         data.lordJawbus.reset()
         data.fieryScuttler.reset()
         data.ragnarok.reset()
         data.plhlegblast.reset()
         data.radioactiveVials.reset()
-        saveData()
+        saveData(force)
     }
 
     private fun resetCrimsonIsleTracker(isConfirmed: Boolean) {
@@ -296,8 +296,12 @@ object CrimsonIsleTracker {
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
     
     fun setRadioactiveVials(count: Int, lastOn: Date?) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -877,11 +877,11 @@ object FishingProfitTracker {
         }
     }
 
-    private fun resetSession() {
+    private fun resetSession(force: Boolean = false) {
         data.session = FishingProfitSourceData()        
-        saveData()
+        saveData(force)
 
-        RareDropMessage.reset() // TODO Make them not dependent
+        RareDropMessage.reset(force) // TODO Make them not dependent
     }
 
     private fun resetTotal() {
@@ -1017,12 +1017,16 @@ object FishingProfitTracker {
         if (!Overlays.fishingProfitTrackerOverlay || !Overlays.resetFishingProfitTrackerOnGameClosed) return
         val session = data.session
         if (session.profitTrackerItems.isNotEmpty() || session.elapsedSeconds > 0 || session.totalProfit != 0.0) {
-            resetSession()
+            resetSession(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Fishing profit tracker [Session] on game closed.")
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/GalateaWaterTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/GalateaWaterTracker.kt
@@ -133,15 +133,15 @@ object GalateaWaterTracker {
         if (Overlays.resetGalateaWaterTrackerOnGameClosed &&
             hasData()
         ) {
-            reset()
+            reset(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Galatea water tracker on game closed.")
         }
     }
 
-    private fun reset() {
+    private fun reset(force: Boolean = false) {
         data.lochEmperor.reset()
         data.nessie.reset()
-        saveData()
+        saveData(force)
     }
 
     private fun resetGalateaWaterTracker(isConfirmed: Boolean) {
@@ -161,7 +161,11 @@ object GalateaWaterTracker {
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/JerryWorkshopTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/JerryWorkshopTracker.kt
@@ -145,15 +145,15 @@ object JerryWorkshopTracker {
         if (Overlays.resetJerryWorkshopTrackerOnGameClosed &&
             Overlays.jerryWorkshopTrackerOverlay &&
             hasData()) {
-            reset()
+            reset(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Jerry Workshop tracker on game closed.")
         }
     }
 
-    private fun reset() {
+    private fun reset(force: Boolean = false) {
         data.yeti.reset()
         data.reindrake.reset()
-        saveData()
+        saveData(force)
     }
 
     private fun resetJerryWorkshopTracker(isConfirmed: Boolean) {
@@ -173,7 +173,11 @@ object JerryWorkshopTracker {
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
@@ -79,8 +79,12 @@ object SeaCreaturesTracker {
         EventBus.subscribe(GameClosedEvent::class, ::onGameClosed)
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 
     private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
@@ -152,14 +156,14 @@ object SeaCreaturesTracker {
         if (Overlays.resetSeaCreaturesTrackerSessionOnGameClosed && 
             Overlays.seaCreaturesTrackerOverlay && 
             data.session.totalCount > 0) {
-            resetSession()
+            resetSession(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Sea creatures tracker [Session] on game closed.")
         }
     }
 
-    private fun resetSession() {
+    private fun resetSession(force: Boolean = false) {
         data.session = SeaCreaturesData()
-        saveData()
+        saveData(force)
     }
 
     private fun resetTotal() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/TreasureFishingTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/TreasureFishingTracker.kt
@@ -124,7 +124,7 @@ object TreasureFishingTracker {
         if (Overlays.resetTreasureFishingTrackerSessionOnGameClosed &&
             Overlays.treasureFishingTrackerOverlay &&
             data.session.catches.totalCatches() > 0) {
-            resetSession()
+            resetSession(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Treasure fishing tracker [Session] on game closed.")
         }
     }
@@ -181,9 +181,9 @@ object TreasureFishingTracker {
         }
     }
 
-    private fun resetSession() {
+    private fun resetSession(force: Boolean = false) {
         data.session = TreasureFishingSessionData()
-        saveData()
+        saveData(force)
     }
 
     private fun resetTotal() {
@@ -294,7 +294,11 @@ object TreasureFishingTracker {
         ))
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WaterHotspotsTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WaterHotspotsTracker.kt
@@ -138,15 +138,15 @@ object WaterHotspotsTracker {
             Overlays.waterHotspotsTrackerOverlay &&
             hasData()
         ) {
-            reset()
+            reset(force = true)
             FeeshMod.LOGGER.info("[Feesh] Automatically reset Water Hotspots tracker on game closed.")
         }
     }
 
-    private fun reset() {
+    private fun reset(force: Boolean = false) {
         data.wikiTiki.reset()
         data.tikiMasks.reset()
-        saveData()
+        saveData(force)
     }
 
     private fun resetWaterHotspotsTracker(isConfirmed: Boolean) {
@@ -166,8 +166,12 @@ object WaterHotspotsTracker {
         }
     }
 
-    private fun saveData() {
-        PersistentDataManager.saveFeeshDataToFileAsync()
+    private fun saveData(force: Boolean = false) {
+        if (force) {
+            PersistentDataManager.forceSaveFeeshDataToFileSync()
+        } else {
+            PersistentDataManager.saveFeeshDataToFileAsync()
+        }
     }
 
     private fun isFishingInHotspot(): Boolean {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/FileUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/FileUtils.kt
@@ -1,7 +1,6 @@
 package com.github.sleepypanda.feesh.utils
 
 import com.github.sleepypanda.feesh.FeeshMod
-import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.google.gson.Gson
 import java.io.File
 import java.lang.reflect.Type
@@ -75,6 +74,33 @@ object FileUtils {
     }
 
     /**
+     * Saves pre-serialized JSON text to a file synchronously.
+     * @param file The file to write to
+     * @param jsonText The JSON text to save
+     * @param saveLock Lock object for synchronization
+     * @param logPrefix Prefix for log messages (e.g., "Catch sounds", "Drop sounds")
+     */
+    fun saveJsonTextToFileSync(
+        file: File,
+        jsonText: String,
+        saveLock: Any,
+        logPrefix: String
+    ) {
+        CommonUtils.runWithCatching("Failed to save $logPrefix data") {
+            synchronized(saveLock) {
+                file.parentFile?.mkdirs()
+                Files.write(
+                    file.toPath(),
+                    jsonText.toByteArray(),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE
+                )
+            }
+        }
+    }
+
+    /**
      * Saves data to a JSON file asynchronously.
      * @param file The file to write to
      * @param data The data to serialize
@@ -93,6 +119,26 @@ object FileUtils {
     ) {
         CompletableFuture.runAsync({
             saveJsonToFileSync(file, data, gson, saveLock, logPrefix)
+        }, executor)
+    }
+
+    /**
+     * Saves pre-serialized JSON text to a file asynchronously.
+     * @param file The file to write to
+     * @param jsonText The JSON text to save
+     * @param executor The executor for async operation
+     * @param saveLock Lock object for synchronization
+     * @param logPrefix Prefix for log messages (e.g., "Catch sounds", "Drop sounds")
+     */
+    fun saveJsonTextToFileAsync(
+        file: File,
+        jsonText: String,
+        executor: Executor,
+        saveLock: Any,
+        logPrefix: String
+    ) {
+        CompletableFuture.runAsync({
+            saveJsonTextToFileSync(file, jsonText, saveLock, logPrefix)
         }, executor)
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/PersistentDataManager.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/PersistentDataManager.kt
@@ -20,7 +20,10 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.ConcurrentModificationException
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -49,11 +52,17 @@ object PersistentDataManager {
     private val overlayCoordsFile: File = File(feeshConfigDir, OVERLAY_COORDS_FILE_NAME)
 
     private val saveLock = Any()
+    private val saveStateLock = Any() // For debouncing intensive file saves
+    private val saveDebounceMs = 1000L
+    private var isFeeshDataSaveScheduled = false
+    private var lastFeeshDataSaveAtMs = 0L
+
     private val gson: Gson = GsonBuilder()
         .setPrettyPrinting()
         .registerTypeAdapter(Date::class.java, UtcDateTypeAdapter)
         .create()
-    private val executor = Executors.newSingleThreadExecutor { r ->
+        
+    private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
         Thread(r, "Feesh-Data-Saver").apply {
             isDaemon = true
         }
@@ -72,9 +81,11 @@ object PersistentDataManager {
     private fun saveAndBackupData() {
         executor.execute {
             val startNanos = System.nanoTime()
+
             FileUtils.saveJsonToFileSync(overlayCoordsFile, overlayCoordsData, gson, saveLock, "Overlay coords")
-            FileUtils.saveJsonToFileSync(feeshDataFile, feeshData, gson, saveLock, "Feesh data")
+            forceSaveFeeshDataToFileSync()
             backupFiles()
+
             val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000
             val elapsedSec = elapsedMs / 1000.0
             FeeshMod.LOGGER.info("[Feesh] Save and backup data finished in ${elapsedMs}ms (${elapsedSec}s).")
@@ -202,7 +213,58 @@ object PersistentDataManager {
         FileUtils.saveJsonToFileAsync(overlayCoordsFile, overlayCoordsData, gson, executor, saveLock, "Overlay coords")
     }
 
+    /*
+     * Schedules save of feeshData to JSON file asynchronously.
+     * Debounces saves to prevent too often file writes.
+     */
     fun saveFeeshDataToFileAsync() {
-        FileUtils.saveJsonToFileAsync(feeshDataFile, feeshData, gson, executor, saveLock, "Feesh data")
+        synchronized(saveStateLock) {
+            if (isFeeshDataSaveScheduled) return
+
+            val now = System.currentTimeMillis()
+            val delayMs = (saveDebounceMs - (now - lastFeeshDataSaveAtMs)).coerceAtLeast(0L)
+            isFeeshDataSaveScheduled = true
+            
+            executor.schedule({
+                val json = serializeFeeshDataToJson()
+                if (json != null) {
+                    FileUtils.saveJsonTextToFileAsync(feeshDataFile, json, executor, saveLock, "Feesh data")
+                    synchronized(saveStateLock) {
+                        isFeeshDataSaveScheduled = false
+                        lastFeeshDataSaveAtMs = System.currentTimeMillis()
+                    }
+                } else {
+                    FeeshMod.LOGGER.error("[Feesh] Failed to serialize Feesh data, skipped saving.")
+                    synchronized(saveStateLock) {
+                        isFeeshDataSaveScheduled = false
+                    }
+                }
+            }, delayMs, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    /*
+     * Forces immediate save of feeshData to JSON file synchronously. Applicable for cases when we need to save data immediately, e.g. on game closed.
+     * No debouncing is applied.
+     */
+    fun forceSaveFeeshDataToFileSync() {
+        val json = serializeFeeshDataToJson()
+        if (json != null) {
+            FileUtils.saveJsonTextToFileSync(feeshDataFile, json, saveLock, "Feesh data")
+        } else {
+            FeeshMod.LOGGER.error("[Feesh] Failed to serialize Feesh data, skipped force saving.")
+        }
+    }
+
+    private fun serializeFeeshDataToJson(): String? {
+        return try {
+            gson.toJson(feeshData)
+        } catch (ex: ConcurrentModificationException) {
+            FeeshMod.LOGGER.error("[Feesh] ConcurrentModificationException occurred while serializing Feesh data.", ex)
+            null
+        } catch (ex: Exception) {
+            FeeshMod.LOGGER.error("[Feesh] Failed to serialize Feesh data.", ex)
+            null
+        }
     }
 }


### PR DESCRIPTION
Avoid too often data.json file writes, and issues like this one:

```
[Feesh] Error occurred in LinkedHashMap.java:1023 in method nextNode - Failed to save Feesh data data
java.util.ConcurrentModificationException: null
	at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1023) ~[?:?]
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1058) ~[?:?]
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1055) ~[?:?]
	at knot/com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:220) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:154) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:490) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.Gson.toJson(Gson.java:944) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.Gson.toJson(Gson.java:899) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.Gson.toJson(Gson.java:848) ~[gson-2.11.0.jar:?]
	at knot/com.google.gson.Gson.toJson(Gson.java:825) ~[gson-2.11.0.jar:?]
	at knot/com.github.sleepypanda.feesh.utils.FileUtils.saveJsonToFileSync(FileUtils.kt:65) ~[Feesh-1.5.0-alpha+1.21.10-fabric.jar:?]
	at knot/com.github.sleepypanda.feesh.utils.FileUtils.saveJsonToFileAsync$lambda$0(FileUtils.kt:95) ~[Feesh-1.5.0-alpha+1.21.10-fabric.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```