### PR TITLE
fix: Fixed own death sound not played for alert on killed by a Mythic sea creature

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,10 +13,13 @@ Released on: ???
 ## Bugfixes
 
 - Track Agatha Contest results even if Fishing profit tracker is paused, while it's visible.
+- Fixed /feeshPlayTestSound to not play sounds when sound mode is Off.
+- Fixed own death sound not played for alert on killed by a Mythic sea creature.
 
 ## Other
 
 - Refactored data saving logic to debounce file writes. This accumulates data changes and saves them once over time, to avoid writing to the file too often.
+- Made Normal sound mode default for new mod users.
 
 # 1.4.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Released on: ???
 ## Bugfixes
 
 - Track Agatha Contest results even if Fishing profit tracker is paused, while it's visible.
-- Fixed /feeshPlayTestSound to not play sounds when sound mode is Off.
+- Fixed /feeshPlayTestSound not playing when sound mode is Off.
 - Fixed own death sound not played for alert on killed by a Mythic sea creature.
 
 ## Other

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -30,10 +30,6 @@ FeeshMod.LOGGER.info("Nessie destination alert: ${mobEntity.x}, ${mobEntity.y}, 
 
 Make sure newly added values in the dropdowns are selected if needed. E.g. if I add new rare drop type to Alerts, alert for this drop should be enabled.
 
-## Alerts
-
-- Player Death sound is not played. :c Probably because player's world is not loaded while they go to spawn on death.
-
 ## Overlays
 
 - Check if "0" key works for numpad in /feeshMoveAllGuis

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NessieDestinationAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NessieDestinationAlert.kt
@@ -136,6 +136,6 @@ object NessieDestinationAlert {
         trackedNessieMobIds[nessieEntityId] = trackedInfo.copy(isDestinationSent = true)
         CommonUtils.showTitle("", "${LIGHT_PURPLE}Nessie ${WHITE}goes to ${GREEN}${BOLD}${destination}${WHITE} cave!")
         SoundUtils.playSound()
-        ChatUtils.sendLocalChat("${LIGHT_PURPLE}${BOLD}Nessie ${WHITE}is swimming to the ${GREEN}${BOLD}${destination}${WHITE} cave. Meet it there!", true)
+        ChatUtils.sendLocalChat("${LIGHT_PURPLE}${BOLD}Nessie ${WHITE}is swimming to the ${GREEN}${BOLD}${destination}${WHITE} cave.", true)
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/commands/PlayTestSoundCommand.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/commands/PlayTestSoundCommand.kt
@@ -54,7 +54,7 @@ object PlayTestSoundCommand {
                     }
                 ) {
                     val soundEvent = getSoundEvent(soundName)
-                    SoundUtils.playSound(soundEvent)
+                    SoundUtils.playSound(soundEvent, skipSoundModeCheck = true)
                 }
             }
             else -> {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/General.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/General.kt
@@ -25,7 +25,7 @@ object General : CategoryKt("General") {
         }
     }
 
-    var soundMode by enum(SoundMode.MEME) {
+    var soundMode by enum(SoundMode.NORMAL) {
         this.name = Translated("Sound mode")
         this.description = Translated("Setups the sound mode for the mod. Meme mode plays meme sounds (customizable), Normal mode plays default MC sounds, Off mode disables all sounds.")
     }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/SoundUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/SoundUtils.kt
@@ -4,36 +4,19 @@ import com.github.sleepypanda.feesh.FeeshMod
 import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.settings.categories.General
 import com.github.sleepypanda.feesh.settings.categories.SoundMode
-import net.minecraft.sound.SoundCategory
 import net.minecraft.sound.SoundEvents
 import net.minecraft.sound.SoundEvent
 import net.minecraft.util.Identifier
 import net.minecraft.client.sound.PositionedSoundInstance
-import net.minecraft.client.sound.SoundInstance
 
 object SoundUtils {
     val SOUNDS_IDENTIFIER_PREFIX = "feesh"
 
-    fun playSound(sound: SoundEvent = SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP) {
-        if (General.soundMode == SoundMode.OFF) return
+    fun playSound(sound: SoundEvent = SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, skipSoundModeCheck: Boolean = false) {
+        if (General.soundMode == SoundMode.OFF && !skipSoundModeCheck) return
 
         val mc = FeeshMod.mc
-        val currentPlayer = mc.player ?: return
-        val soundId = sound.id
-        val soundInstance = PositionedSoundInstance(
-            soundId,
-            SoundCategory.MASTER,
-            1.0f,
-            1.0f,
-            currentPlayer.random,
-            false,
-            0,
-            SoundInstance.AttenuationType.LINEAR,
-            currentPlayer.x,
-            currentPlayer.y,
-            currentPlayer.z,
-            false
-        )
+        val soundInstance = PositionedSoundInstance.master(sound, 1.0f, 1.0f)
 
         mc.soundManager.play(soundInstance)
     }


### PR DESCRIPTION
- Fixed own death sound not played for alert on killed by a Mythic sea creature.
- Fixed /feeshPlayTestSound not playing when sound mode is Off.
- Made Normal sound mode default for new mod users.