### PR TITLE
refactor: Changed way how keybinds are registered

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ Released on: ???
 - Made sea creature names and drop names searchable in settings, to easier identify selectlists where they can be toggled.
 - Refactored way of detecting new entities spawned in the world.
 - Refactored data saving logic to debounce file writes. This accumulates data changes and saves them once over time, to avoid writing to the file too often.
+- Refactored way how keybinds are registered. Hopefully this will fix periodic keybind reset issues.
 
 Take the fish:
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/FeeshMod.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/FeeshMod.kt
@@ -82,12 +82,12 @@ import com.github.sleepypanda.feesh.utils.data.CustomSoundsManager
 import com.github.sleepypanda.feesh.utils.gui.MoveGuis
 import com.teamresourceful.resourcefulconfig.api.loader.Configurator
 import net.minecraft.SharedConstants
-import net.fabricmc.api.ModInitializer
+import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.client.MinecraftClient
 import org.slf4j.LoggerFactory
 
-class FeeshMod : ModInitializer {
+class FeeshMod : ClientModInitializer {
     companion object {
         internal const val MOD_ID = "feesh"
         internal const val MOD_NAME = "Feesh"
@@ -113,7 +113,7 @@ class FeeshMod : ModInitializer {
         INSTANCE = this
     }
 
-    override fun onInitialize() {
+    override fun onInitializeClient() {
         version = getModVersion()
         LOGGER.info("Loading $MOD_NAME v$version for ${mcVersion}...")
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
@@ -11,7 +11,6 @@ import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
 import com.github.sleepypanda.feesh.utils.EntityUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
-import com.github.sleepypanda.feesh.utils.KeybindUtils
 import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
 import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
@@ -23,7 +22,6 @@ import net.minecraft.text.Text
 import net.minecraft.text.Style
 import net.minecraft.text.ClickEvent.RunCommand
 import net.minecraft.text.HoverEvent.ShowText
-import org.lwjgl.glfw.GLFW
 import net.minecraft.util.math.Vec3d
 
 object HotspotFoundMessage {
@@ -34,21 +32,17 @@ object HotspotFoundMessage {
     private const val NEAREST_HOTSPOT_RANGE_FROM_PLAYER = 10.0
 
     fun init() {
-        registerKeybinds()
-
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
         EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
         EventBus.subscribe(ArmorStandDespawnedEvent::class, ::onHotspotDespawned)
     }
 
-    private fun registerKeybinds() {
-        KeybindUtils.registerKeybind("key.feesh.shareHotspotPartyChat", GLFW.GLFW_KEY_UNKNOWN) {
-            sendMessageWithNearestHotspot(true)
-        }
+    fun shareNearestHotspotToParty() {
+        sendMessageWithNearestHotspot(true)
+    }
 
-        KeybindUtils.registerKeybind("key.feesh.shareHotspotAllChat", GLFW.GLFW_KEY_UNKNOWN) {
-            sendMessageWithNearestHotspot(false)
-        }
+    fun shareNearestHotspotToAll() {
+        sendMessageWithNearestHotspot(false)
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/LootshareMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/LootshareMessage.kt
@@ -2,17 +2,15 @@ package com.github.sleepypanda.feesh.features.chat
 
 import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
-import com.github.sleepypanda.feesh.utils.KeybindUtils
-import net.minecraft.client.option.KeyBinding
-import org.lwjgl.glfw.GLFW
 
 object LootshareMessage {
     const val LOOTSHARE_MESSAGE = "Lootshare!"
 
-    fun init() {       
-        KeybindUtils.registerKeybind("key.feesh.lootshareToPartyChat", GLFW.GLFW_KEY_UNKNOWN) {
-            sendLootshareMessage()
-        }
+    fun init() {
+    }
+
+    fun triggerLootshareMessage() {
+        sendLootshareMessage()
     }
 
     private fun sendLootshareMessage() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/commands/PauseAllTrackersCommand.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/commands/PauseAllTrackersCommand.kt
@@ -2,13 +2,10 @@ package com.github.sleepypanda.feesh.features.commands
 
 import com.github.sleepypanda.feesh.utils.ChatUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
-import com.github.sleepypanda.feesh.utils.KeybindUtils
 import com.github.sleepypanda.feesh.utils.RegisterUtils
 import com.github.sleepypanda.feesh.features.overlays.SeaCreaturesPerHourTracker
 import com.github.sleepypanda.feesh.features.overlays.FishingProfitTracker
 import com.github.sleepypanda.feesh.features.overlays.MagmaCoreFishingTracker
-import net.minecraft.client.option.KeyBinding
-import org.lwjgl.glfw.GLFW
 
 object PauseAllTrackersCommand {
     const val COMMAND_NAME = "feeshPauseAllTrackers"
@@ -17,10 +14,10 @@ object PauseAllTrackersCommand {
         RegisterUtils.command(COMMAND_NAME) {
             pauseAllTrackers()
         }
+    }
 
-        KeybindUtils.registerKeybind("key.feesh.pauseAllTrackers", GLFW.GLFW_KEY_PAUSE) {
-            pauseAllTrackers()
-        }
+    fun triggerPauseAllTrackers() {
+        pauseAllTrackers()
     }
 
     private fun pauseAllTrackers() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BarnFishingTimer.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BarnFishingTimer.kt
@@ -17,14 +17,12 @@ import com.github.sleepypanda.feesh.utils.gui.GuiButton
 import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
 import com.github.sleepypanda.feesh.utils.RegisterUtils
-import com.github.sleepypanda.feesh.utils.KeybindUtils
 import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
 import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 import com.github.sleepypanda.feesh.constants.SeaCreatures
 import com.github.sleepypanda.feesh.constants.Sounds
 import com.github.sleepypanda.feesh.settings.categories.General
 import com.github.sleepypanda.feesh.settings.categories.SoundMode
-import org.lwjgl.glfw.GLFW
 import net.minecraft.entity.decoration.ArmorStandEntity
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.component.DataComponentTypes
@@ -66,7 +64,6 @@ object BarnFishingTimer {
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
         EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
         registerCommands()
-        registerKeybinds()
     }
 
     private fun registerCommands() {
@@ -75,10 +72,8 @@ object BarnFishingTimer {
         }
     }
 
-    private fun registerKeybinds() {
-        KeybindUtils.registerKeybind("key.feesh.resetBarnFishingTimer", GLFW.GLFW_KEY_UNKNOWN) {
-            resetSeaCreaturesCountAndTimer()
-        }
+    fun triggerResetKeybind() {
+        resetSeaCreaturesCountAndTimer()
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/KeybindUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/KeybindUtils.kt
@@ -2,6 +2,10 @@ package com.github.sleepypanda.feesh.utils
 
 import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
+import com.github.sleepypanda.feesh.features.chat.HotspotFoundMessage
+import com.github.sleepypanda.feesh.features.chat.LootshareMessage
+import com.github.sleepypanda.feesh.features.commands.PauseAllTrackersCommand
+import com.github.sleepypanda.feesh.features.overlays.BarnFishingTimer
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.client.util.InputUtil
 import net.minecraft.util.Identifier
@@ -10,14 +14,37 @@ import org.lwjgl.glfw.GLFW
 
 object KeybindUtils {
     val FEESH_CATEGORY = KeyBinding.Category(Identifier.of("feesh", "keybinds")) // Keys are localized in resources/assets/feesh/lang/en_us.json
-    
-    private val keybinds = mutableMapOf<KeyBinding, () -> Unit>()
+    private val keybindCallbacks = mutableListOf<Pair<KeyBinding, () -> Unit>>()
+    private var keybindsRegistered = false
 
     fun init() {
+        registerAllKeybinds()
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
     }
 
-    fun registerKeybind(id: String, keyCode: Int = GLFW.GLFW_KEY_UNKNOWN, callback: () -> Unit): KeyBinding {
+    private fun registerAllKeybinds() {
+        if (keybindsRegistered) return
+
+        registerKeybind("key.feesh.shareHotspotPartyChat", GLFW.GLFW_KEY_UNKNOWN) {
+            HotspotFoundMessage.shareNearestHotspotToParty()
+        }
+        registerKeybind("key.feesh.shareHotspotAllChat", GLFW.GLFW_KEY_UNKNOWN) {
+            HotspotFoundMessage.shareNearestHotspotToAll()
+        }
+        registerKeybind("key.feesh.lootshareToPartyChat", GLFW.GLFW_KEY_UNKNOWN) {
+            LootshareMessage.triggerLootshareMessage()
+        }
+        registerKeybind("key.feesh.resetBarnFishingTimer", GLFW.GLFW_KEY_UNKNOWN) {
+            BarnFishingTimer.triggerResetKeybind()
+        }
+        registerKeybind("key.feesh.pauseAllTrackers", GLFW.GLFW_KEY_PAUSE) {
+            PauseAllTrackersCommand.triggerPauseAllTrackers()
+        }
+
+        keybindsRegistered = true
+    }
+
+    private fun registerKeybind(id: String, keyCode: Int = GLFW.GLFW_KEY_UNKNOWN, callback: () -> Unit): KeyBinding {
         val keyBinding = KeyBinding(
             id,
             InputUtil.Type.KEYSYM,
@@ -25,12 +52,12 @@ object KeybindUtils {
             FEESH_CATEGORY
         )
         KeyBindingHelper.registerKeyBinding(keyBinding)
-        keybinds[keyBinding] = callback
+        keybindCallbacks.add(keyBinding to callback)
         return keyBinding
     }
 
     private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
-        keybinds.forEach { (keyBinding, callback) ->
+        keybindCallbacks.forEach { (keyBinding, callback) ->
             if (keyBinding.wasPressed()) {
                 callback()
             }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,7 @@
 	"icon": "assets/feesh/icon.png",
 	"environment": "client",
 	"entrypoints": {
-	  "main": ["com.github.sleepypanda.feesh.FeeshMod"]
+	  "client": ["com.github.sleepypanda.feesh.FeeshMod"]
 	},
 	"mixins": ["feesh.mixins.json"],
 	"depends": {


### PR DESCRIPTION
Hopefully, centralized keybind registration will fix periodic keybind reset issues.

Also moved all mod startup logic into client initializer, like it's done in other mods.

Context:
Registration timing is risky: keybinds are registered from FeeshMod.onInitialize() (ModInitializer), not a dedicated client entrypoint. If Minecraft options are loaded before these bindings exist, custom values can be ignored and defaults used, then written back on exit.