### PR TITLE
feat: Shortened coordinates chat message for Hotspots and Mythic creatures in Bayou

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Released on: ???
 - Added setting to autoshare Nessie's destination to party chat [disabled by default].
 - Added Golden Bait and Treasure bait to the Fishing profit tracker, because of Seal pet's perk.
 - Added Consumables tracker which shows consumed Moby-Duck's remaining time [disabled by default]. Also has expiration alert.
+- Shortened coordinates chat message for Hotspots and Mythic creatures in Bayou, as there is only one zone on the island and no need to mention it.
 
 ## Bugfixes
 

--- a/docs/Future ideas & requests.md
+++ b/docs/Future ideas & requests.md
@@ -7,6 +7,16 @@
 - When there is no fishing rod in hand, some trackers can be hidden (optional setting).
 - Pause button pauses all widget's timers so you dont have to click each widget's button individually. Same thing that keybind does.
 
+## Sea creature alerts
+
+- Could be triggered for any sea creature, not only for rares
+
+## Barn fishing timer
+
+- Detect personal cap before it actually happened
+- Change overlay/alerting so it can rely on own creatures
+- Split entities count as 1 (e.g. 3 Baby Magma Slugs give 1 to cap)
+
 ## Sea creature HP tracker
 
 - Add custom Ragnarok immunity timer - when it goes below 50% hp (e.g. 62.4). Max HP is 125 mil, or 250 on Derpy. It takes around 12 seconds, but if server is laggy it takes unpredictable time.

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -3,8 +3,7 @@
 - Alpha:
   - Added the Personal Sea Creature Cap from the Crimson Isle to every island in the game
   - Added the functionality of your current bait being slown in slot #9 while fishing
-  - CHaning crafting recipies for Ml-based items ig
-  - There is not enough space for another Sea Creature! Kill some to make space for new ones!
+  - Chaning crafting recipies for Ml-based items ig
 - Catches/h for treasures
 - Link to changelog? Change hotspot sounds?
 - Some people need other sea creatures alerts, e.g. Ent or Night Squid
@@ -22,6 +21,7 @@
 - Sometimes current world&zone is detected wrongly
 - Ragnarok immunity timer
 - Someone has no Vial title/sound (I checked and did not reproduce, I had my title/sound as usual)
+- Manual "set tracker drops" command does not reset "sc since last" for that drop.
 - Fished coins to add via the command.
 - Carmine dye into tracker
 - Autoupdates

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/HotspotFoundMessage.kt
@@ -164,7 +164,7 @@ object HotspotFoundMessage {
 
     private fun getMessage(x: Double, y: Double, z: Double, perk: String?, needsMessageId: Boolean): String {
         val location = CommonUtils.getFormattedLocation(x, y, z)
-        val zone = WorldUtils.getZoneName()
+        val zone = if (WorldUtils.getWorldName() == WorldUtils.BACKWATER_BAYOU) null else WorldUtils.getZoneName() // Bayou has single zone so no need to show it
         val messageId = if (needsMessageId) " | ${CommonUtils.getMessageId()}" else ""
 
         val perkText = if (perk != null) "${perk.removeFormatting()} " else ""

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareCatchAllChatMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareCatchAllChatMessage.kt
@@ -35,8 +35,8 @@ object RareCatchAllChatMessage {
         val player = FeeshMod.mc.player ?: return ""
         val location = CommonUtils.getFormattedLocation(player.getX(), player.getY(), player.getZ())
         val scMessage = if (isDoubleHooked) "${seaCreatureName} x2" else "${seaCreatureName}"
-        val zone = WorldUtils.getZoneName()
-        val zoneText = if (!zone.isNullOrEmpty()) " at ${zone}" else ""
+        val zone = if (WorldUtils.getWorldName() == WorldUtils.BACKWATER_BAYOU) null else WorldUtils.getZoneName() // Bayou has single zone so no need to show it
+        val zoneText = if (!zone.isNullOrEmpty()) " at $zone" else ""
         val messageId = CommonUtils.getMessageId()
     
         var message = "${location} | ${scMessage}${zoneText} | ${messageId}"


### PR DESCRIPTION
There is only one zone on the island and no need to mention it in the message