### PR TITLE
fix: Fixed some baits being added to Fishing profit tracker from slot #9

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ Released on: ???
 
 ## Bugfixes
 
+- Fixed some baits being added to Fishing profit tracker after adding Bait Bag preview in slot #9.
+
 # 1.6.1
 
 Released on: 2026-05-02

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -728,6 +728,7 @@ object FishingProfitTracker {
         val player = FeeshMod.mc.player ?: return result
 
         for (i in 0..35) {
+            if (i == 8) continue // Bottom-right slot in player inventory UI (hotbar rightmost slot) which contains Bait Bag preview
             val stack = player.inventory.getItem(i)
             if (stack.isEmpty) continue
             var slotItemName = ItemUtils.getCleanItemName(stack.hoverName.getFormattedString())


### PR DESCRIPTION
Disabled reading items from bottom right Inventory slot (SB menu / Bait Bag preview)