### PR TITLE
feat: Delay before unhide players

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -5,6 +5,7 @@ Released on: ???
 ## Features
 
 - Added option to use Ctrl+Click instead of Click to interact with overlay buttons. This might help to avoid undesired overlays interactions when in Chat/Inventory.
+- Added option to set delay before players get unhidden for "Hide players near bobber" feature, to avoid players flickering on rod re-cast.
 
 ## Bugfixes
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/BaitAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/BaitAlert.kt
@@ -30,7 +30,7 @@ object BaitAlert {
     private fun onBaitChanged(event: BaitChangedEvent) {
         CommonUtils.runWithCatching("Failed to alert on bait change") {
             if (!Alerts.alertOnBaitChanged || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return
-            if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+            if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
             if (isInFishingBag()) return
 
             ChatUtils.sendLocalChat("${WHITE}Bait changed from ${event.oldBaitDisplayName} ${WHITE}to ${event.newBaitDisplayName}${WHITE}.", true)
@@ -42,7 +42,7 @@ object BaitAlert {
     private fun onBaitRunningOut(event: BaitRunningOutEvent) {
         CommonUtils.runWithCatching("Failed to alert on bait running out") {
             if (!Alerts.alertOnBaitRunningOut || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return
-            if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+            if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
             if (isInFishingBag()) return
             if (event.baitName.isBlank()) return
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/FishingBagDisabledAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/FishingBagDisabledAlert.kt
@@ -82,7 +82,7 @@ object FishingBagDisabledAlert {
                 if (title.contains(FISHING_BAG_TITLE_CONTAINS)) return
             }
 
-            val isHookActive = FishingHookUtils.isFishingHookActive()
+            val isHookActive = FishingHookUtils.isFishingHookSubmerged()
             if (!isHookActive) return
 
             CommonUtils.showTitle("${RED}Enable fishing bag!")

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/HotspotGoneAlert.kt
@@ -76,10 +76,10 @@ object HotspotGoneAlert {
         CommonUtils.runWithCatching("Failed to track latest Hotspot") {
             if (!Alerts.alertOnHotspotGone || !WorldUtils.isInSkyblock() || !WorldUtils.isInHotspotFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
 
-            val isHookActive = FishingHookUtils.isFishingHookActive()
+            val isHookActive = FishingHookUtils.isFishingHookSubmerged()
             if (!isHookActive) return
 
-            val playerHook = FishingHookUtils.getActiveFishingHook() ?: return
+            val playerHook = FishingHookUtils.getSubmergedFishingHook() ?: return
             val closestHotspot = HotspotUtils.findClosestHotspotInRange(Vec3(playerHook.x, playerHook.y, playerHook.z), NEAREST_HOTSPOT_RANGE_FROM_HOOK) ?: return
 
             lastClosestHotspot = closestHotspot

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NessieDestinationAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NessieDestinationAlert.kt
@@ -86,7 +86,7 @@ object NessieDestinationAlert {
     private fun onArmorStandLoaded(event: ArmorStandDetailsLoadedEvent) {
         if (!Alerts.alertOnNessieDestination || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.GALATEA) return
         if (!event.customNameUnformatted.contains(NESSIE_NAME)) return
-        if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         EntityUtils.parseSeaCreatureNametag(event.entity, listOf(NESSIE_NAME)) ?: return
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
@@ -53,7 +53,7 @@ object NonFishingArmorAlert {
                 if (diffMillis < 10_000) return
             }
 
-            val isHookActive = FishingHookUtils.isFishingHookActive()
+            val isHookActive = FishingHookUtils.isFishingHookSubmerged()
             if (!isHookActive) return
 
             lastHookDetectedAt = Date()

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BaitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BaitTracker.kt
@@ -26,7 +26,7 @@ object BaitTracker {
         .setApplyCustomStyleKey { Overlays.baitTrackerCustomStyle }
         .setCondition {
             WorldUtils.isInFishingWorld() &&
-                FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+                FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -51,7 +51,7 @@ object BaitTracker {
             if (!Overlays.baitTrackerOverlay ||
                 !WorldUtils.isInSkyblock() ||
                 !WorldUtils.isInFishingWorld() ||
-                !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+                !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
             ) {
                 gui.clearLines()
                 return

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BayouTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/BayouTracker.kt
@@ -54,7 +54,7 @@ object BayouTracker {
         .setApplyCustomStyleKey { Overlays.bayouTrackerCustomStyle }
         .setCondition {
             WorldUtils.getWorldName() == WorldUtils.BACKWATER_BAYOU &&
-                FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+                FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -119,7 +119,7 @@ object BayouTracker {
 
         if (!hasData()) return
         if (!Overlays.bayouTrackerOverlay || !WorldUtils.isInSkyblock() ||
-            !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+            !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         ) return
         if (WorldUtils.getWorldName() != WorldUtils.BACKWATER_BAYOU) return
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/CrimsonIsleTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/CrimsonIsleTracker.kt
@@ -74,7 +74,7 @@ object CrimsonIsleTracker {
         .setSettingsKey { Overlays.crimsonIsleTrackerOverlay }
         .setApplyCustomStyleKey { Overlays.crimsonIsleTrackerCustomStyle }
         .setCondition {
-            WorldUtils.getWorldName() == WorldUtils.CRIMSON_ISLE && FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+            WorldUtils.getWorldName() == WorldUtils.CRIMSON_ISLE && FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -232,7 +232,7 @@ object CrimsonIsleTracker {
     private fun updateGuiLines() {
         gui.clearLines()
 
-        if (!Overlays.crimsonIsleTrackerOverlay || !WorldUtils.isInSkyblock() || !FishingHookUtils.wasFishingHookActiveMinutesAgo(5) || WorldUtils.getWorldName() != WorldUtils.CRIMSON_ISLE) return
+        if (!Overlays.crimsonIsleTrackerOverlay || !WorldUtils.isInSkyblock() || !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5) || WorldUtils.getWorldName() != WorldUtils.CRIMSON_ISLE) return
         if (!hasData()) return
 
         val isInHotspot = isFishingInHotspot()
@@ -321,7 +321,7 @@ object CrimsonIsleTracker {
 
     private fun isFishingInHotspot(): Boolean {
         if (WorldUtils.getWorldName() != WorldUtils.CRIMSON_ISLE) return false
-        return FishingHookUtils.wasFishingHookActiveInHotspotSecondsAgo(15)
+        return FishingHookUtils.wasFishingHookSubmergedInHotspotSecondsAgo(15)
     }
 
     private fun isInPlhlegblastPool(): Boolean {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingFestivalTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingFestivalTracker.kt
@@ -132,7 +132,7 @@ object FishingFestivalTracker {
             WorldUtils.isInSkyblock() &&
             WorldUtils.isInFishingWorld() && 
             hasSharkData() &&
-            FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+            FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
     }
 
     private fun hasSharkData(): Boolean {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingHookTimer.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingHookTimer.kt
@@ -76,7 +76,7 @@ object FishingHookTimer {
             return
         }
 
-        val fishingHook = FishingHookUtils.getFishingHook() ?: run {
+        val fishingHook = FishingHookUtils.getActiveFishingHook() ?: run {
             fishingHookTimer = null
             gui.clearLines()
             return

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -266,7 +266,7 @@ object FishingProfitTracker {
 
     private fun isTrackerVisible(): Boolean {
         if (!Overlays.fishingProfitTrackerOverlay || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return false
-        if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(HIDE_OVERLAY_AFTER_HOOK_MINUTES)) return false
+        if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(HIDE_OVERLAY_AFTER_HOOK_MINUTES)) return false
 
         val viewMode = getCurrentViewMode()
         val session = data.session
@@ -537,7 +537,7 @@ object FishingProfitTracker {
         }
 
         val prevIsActive = isSessionActive
-        val isHookActive = FishingHookUtils.isFishingHookActive()
+        val isHookActive = FishingHookUtils.isFishingHookSubmerged()
 
         // Start fishing timer after pause or when tracker was empty
         if (isHookActive) {
@@ -553,7 +553,7 @@ object FishingProfitTracker {
         }
 
         if (!isSessionActive || !isTrackerVisible()) return
-        val lastHookSeenAt = FishingHookUtils.lastActiveFishingHookSeenAt() ?: return
+        val lastHookSeenAt = FishingHookUtils.lastSubmergedFishingHookSeenAt() ?: return
         val elapsedSinceHook = (Date().time - lastHookSeenAt.time) / 1000
         if (elapsedSinceHook < Overlays.trackersAutoPauseSeconds) {
             data.session.elapsedSeconds += 1

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/GalateaWaterTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/GalateaWaterTracker.kt
@@ -50,7 +50,7 @@ object GalateaWaterTracker {
         .setApplyCustomStyleKey { Overlays.galateaWaterTrackerCustomStyle }
         .setCondition {
             WorldUtils.getWorldName() == WorldUtils.GALATEA &&
-                FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+                FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -115,7 +115,7 @@ object GalateaWaterTracker {
         gui.clearLines()
 
         if (!hasData()) return
-        if (!Overlays.galateaWaterTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.GALATEA || !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (!Overlays.galateaWaterTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.GALATEA || !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         val lines = mutableListOf<LineInfo>()
         lines.add(LineInfo(baseTitle))

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/JerryWorkshopTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/JerryWorkshopTracker.kt
@@ -52,7 +52,7 @@ object JerryWorkshopTracker {
         .setApplyCustomStyleKey { Overlays.jerryWorkshopTrackerCustomStyle }
         .setCondition {
             WorldUtils.getWorldName() == WorldUtils.JERRY_WORKSHOP &&
-            FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+            FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -116,7 +116,7 @@ object JerryWorkshopTracker {
         gui.clearLines()
 
         if (!hasData()) return
-        if (!Overlays.jerryWorkshopTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.JERRY_WORKSHOP || !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (!Overlays.jerryWorkshopTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.JERRY_WORKSHOP || !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         val lines = mutableListOf<LineInfo>()
         lines.add(LineInfo(baseTitle))

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/LotusAtollTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/LotusAtollTracker.kt
@@ -59,7 +59,7 @@ object LotusAtollTracker {
         .setApplyCustomStyleKey { Overlays.lotusAtollTrackerCustomStyle }
         .setCondition {
             WorldUtils.getWorldName() == WorldUtils.LOTUS_ATOLL &&
-                FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+                FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -138,7 +138,7 @@ object LotusAtollTracker {
 
         if (!hasData()) return
         if (!Overlays.lotusAtollTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.LOTUS_ATOLL) return
-        if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         val lines = mutableListOf<LineInfo>()
         lines.add(LineInfo(baseTitle))

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/MagmaCoreFishingTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/MagmaCoreFishingTracker.kt
@@ -207,7 +207,7 @@ object MagmaCoreFishingTracker {
 
     private fun isTrackerVisible(): Boolean {
         if (!Overlays.magmaCoreFishingTrackerOverlay || !WorldUtils.isInSkyblock() || WorldUtils.getWorldName() != WorldUtils.CRYSTAL_HOLLOWS) return false
-        if (!FishingHookUtils.wasFishingHookActiveMinutesAgo(HIDE_OVERLAY_MINUTES)) return false
+        if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(HIDE_OVERLAY_MINUTES)) return false
         if (lastSeaCreatureCaughtAt == null) return false
 
         val elapsedSinceCatch = (Date().time - lastSeaCreatureCaughtAt!!.time) / 1000

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesPerHourTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesPerHourTracker.kt
@@ -44,7 +44,7 @@ object SeaCreaturesPerHourTracker {
         .setApplyCustomStyleKey { Overlays.seaCreaturesPerHourTrackerCustomStyle }
         .setCondition {
             WorldUtils.isInFishingWorld() &&
-            FishingHookUtils.wasFishingHookActiveMinutesAgo(HIDE_OVERLAY_MINUTES)
+            FishingHookUtils.wasFishingHookSubmergedMinutesAgo(HIDE_OVERLAY_MINUTES)
         }
 
     fun init() {
@@ -130,7 +130,7 @@ object SeaCreaturesPerHourTracker {
             !WorldUtils.isInSkyblock() ||
             !WorldUtils.isInFishingWorld() ||
             (totalSeaCreaturesCaughtCount == 0) ||
-            !FishingHookUtils.wasFishingHookActiveMinutesAgo(HIDE_OVERLAY_MINUTES)
+            !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(HIDE_OVERLAY_MINUTES)
         ) return
 
         val elapsedHours = elapsedSeconds / 3600.0

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/SeaCreaturesTracker.kt
@@ -78,7 +78,7 @@ object SeaCreaturesTracker {
         .setApplyCustomStyleKey { Overlays.seaCreaturesTrackerCustomStyle }
         .setCondition {
             WorldUtils.isInFishingWorld() &&
-            FishingHookUtils.wasFishingHookActiveMinutesAgo(5)
+            FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)
         }
 
     fun init() {
@@ -114,7 +114,7 @@ object SeaCreaturesTracker {
         val valueToAdd = if (isDoubleHook) 2 else 1
 
         // Do not track Vanquishers if not fishing
-        if (seaCreatureName == "Vanquisher" && !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (seaCreatureName == "Vanquisher" && !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         trackSeaCreatureCatch(data.session, seaCreatureName, valueToAdd, isDoubleHook)
         trackSeaCreatureCatch(data.total, seaCreatureName, valueToAdd, isDoubleHook)
@@ -129,7 +129,7 @@ object SeaCreaturesTracker {
 
         val seaCreatureName = event.seaCreatureName
 
-        if (seaCreatureName == "Vanquisher" && !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+        if (seaCreatureName == "Vanquisher" && !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
         trackSeaCreatureCocoon(data.session, seaCreatureName)
         trackSeaCreatureCocoon(data.total, seaCreatureName)
@@ -507,7 +507,7 @@ object SeaCreaturesTracker {
         CommonUtils.runWithCatching("Failed to update GUI lines in Sea creatures tracker") {
             gui.clearLines()
 
-            if (!Overlays.seaCreaturesTrackerOverlay || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld() || !FishingHookUtils.wasFishingHookActiveMinutesAgo(5)) return
+            if (!Overlays.seaCreaturesTrackerOverlay || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld() || !FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
 
             val viewMode = getCurrentViewMode()
             val sourceObj = getSourceObject(viewMode)

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WaterHotspotsTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WaterHotspotsTracker.kt
@@ -54,7 +54,7 @@ object WaterHotspotsTracker {
         .setApplyCustomStyleKey { Overlays.waterHotspotsTrackerCustomStyle }
         .setCondition {
             WorldUtils.isInWaterHotspotFishingWorld() &&
-                FishingHookUtils.wasFishingHookActiveInHotspotSecondsAgo(300)
+                FishingHookUtils.wasFishingHookSubmergedInHotspotSecondsAgo(300)
         }
 
     fun init() {
@@ -119,7 +119,7 @@ object WaterHotspotsTracker {
 
         if (!hasData()) return
         if (!Overlays.waterHotspotsTrackerOverlay || !WorldUtils.isInSkyblock() || !WorldUtils.isInWaterHotspotFishingWorld() ||
-            !FishingHookUtils.wasFishingHookActiveInHotspotSecondsAgo(300)
+            !FishingHookUtils.wasFishingHookSubmergedInHotspotSecondsAgo(300)
         ) return
 
         val lines = mutableListOf<LineInfo>()
@@ -176,7 +176,7 @@ object WaterHotspotsTracker {
 
     private fun isFishingInHotspot(): Boolean {
         if (!WorldUtils.isInWaterHotspotFishingWorld()) return false
-        return FishingHookUtils.wasFishingHookActiveInHotspotSecondsAgo(15)
+        return FishingHookUtils.wasFishingHookSubmergedInHotspotSecondsAgo(15)
     }
 
     fun setTikiMasks(count: Int, lastOn: Date?) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HidePlayersNearBobber.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HidePlayersNearBobber.kt
@@ -24,7 +24,8 @@ object HidePlayersNearBobber {
         if (!(entity.uuid.version() == 4 || entity.uuid.version() == 1)) return false // Exclude NPCs
 
         val hook = FishingHookUtils.getFishingHook() ?: return false
-        val distanceBlocks = EntityUtils.getDistance(hook.x, hook.y, hook.z, entity.x, entity.y, entity.z)
-        return distanceBlocks <= WorldRendering.hidePlayersNearBobberDistance
+        val maxDistanceSqr = WorldRendering.hidePlayersNearBobberDistance * WorldRendering.hidePlayersNearBobberDistance
+        val actualDistanceSqr = EntityUtils.getDistanceSqr(hook.x, hook.y, hook.z, entity.x, entity.y, entity.z)
+        return actualDistanceSqr <= maxDistanceSqr
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HidePlayersNearBobber.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HidePlayersNearBobber.kt
@@ -6,12 +6,14 @@ import com.github.sleepypanda.feesh.utils.EntityUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
 import com.github.sleepypanda.feesh.utils.FishingHookUtils
 import net.minecraft.world.entity.player.Player
+import kotlin.math.pow
 
 object HidePlayersNearBobber {
     /**
      * Returns true if the given player entity should not be rendered (hidden).
-     * Hides other players when the local player has fishing rod cast and the player
+     * Hides other players when the local player has fishing rod casted and the player
      * is within the configured distance from the local player's fishing hook.
+     * Also applies an optional delay to keep players hidden for a while after the fishing hook disappears, to avoid flickering while recasting.
      */
     @JvmStatic
     fun shouldHidePlayer(entity: Player): Boolean {
@@ -21,11 +23,18 @@ object HidePlayersNearBobber {
         val localPlayer = FeeshMod.mc.player ?: return false
         if (entity == localPlayer) return false
 
-        if (!(entity.uuid.version() == 4 || entity.uuid.version() == 1)) return false // Exclude NPCs
+        val version = entity.uuid.version()
+        if (!(version == 4 || version == 1)) return false // Exclude NPCs and mobs
 
-        val hook = FishingHookUtils.getFishingHook() ?: return false
-        val maxDistanceSqr = WorldRendering.hidePlayersNearBobberDistance * WorldRendering.hidePlayersNearBobberDistance
+        val unhideDelay = WorldRendering.hidePlayersNearBobberUnhideDelay.coerceAtLeast(0)
+        val wasFishingHookActive = FishingHookUtils.getActiveFishingHook() != null ||
+            (unhideDelay > 0 && FishingHookUtils.wasFishingHookActiveSecondsAgo(unhideDelay))
+        if (!wasFishingHookActive) return false
+
+        val hook = FishingHookUtils.getLastActiveFishingHook() ?: return false
+        val maxDistanceSqr = WorldRendering.hidePlayersNearBobberDistance.toDouble().pow(2)
         val actualDistanceSqr = EntityUtils.getDistanceSqr(hook.x, hook.y, hook.z, entity.x, entity.y, entity.z)
+        
         return actualDistanceSqr <= maxDistanceSqr
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/WorldRendering.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/WorldRendering.kt
@@ -62,13 +62,20 @@ object WorldRendering : CategoryKt("World Rendering") {
 
     var hidePlayersNearBobber by boolean(false) {
         this.name = Translated("Hide players near bobber")
-        this.description = Translated("Hides other players when your fishing rod is cast, if they are within the configured distance from your fishing hook.")
+        this.description = Translated("Hides other players when your fishing rod is casted, if they are within the configured distance from your fishing hook.")
     }
 
     var hidePlayersNearBobberDistance by int(5) {
         this.name = Translated("Distance from bobber")
-        this.description = Translated("Maximum distance (blocks) from your fishing hook within which other players are hidden. Only applies when fishing rod is casted.")
+        this.description = Translated("Maximum distance (blocks) from your fishing hook within which other players are hidden.")
         this.range = 1..10
+        this.slider = true
+    }
+
+    var hidePlayersNearBobberUnhideDelay by int(0) {
+        this.name = Translated("Unhide delay")
+        this.description = Translated("Delay in seconds to keep players hidden after your bobber disappears.")
+        this.range = 0..5
         this.slider = true
     }
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/FishingHookUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/FishingHookUtils.kt
@@ -8,9 +8,9 @@ import java.util.Date
 import net.minecraft.world.phys.Vec3
 
 /** 
- * Information about the casted fishing hook. It can be casted into any blocks, air or fluid.
+ * Information about the active fishing hook. It can be casted into any blocks, air or fluid.
  */
-data class FishingHookInfo(
+data class ActiveFishingHookInfo(
     var x: Double = 0.0,
     var y: Double = 0.0,
     var z: Double = 0.0,
@@ -30,7 +30,10 @@ data class SubmergedFishingHookInfo(
 )
 
 object FishingHookUtils {
-    private var fishingHook: FishingHookInfo? = null
+    private var activeFishingHook: ActiveFishingHookInfo? = null
+    private var activeFishingHookSeenAt: Date? = null
+    private var lastActiveFishingHook: ActiveFishingHookInfo? = null // Used to store the last known fishing hook even if it is not present anymore
+
     private var submergedFishingHook: SubmergedFishingHookInfo? = null
     private var submergedFishingHookSeenAt: Date? = null
     private var submergedFishingHookInHotspotSeenAt: Date? = null
@@ -41,10 +44,35 @@ object FishingHookUtils {
     }
 
     /**
-     * Check if the player's fishing hook is active (submerged into water/lava, or casted into the ground for dirt rod).
+     * Get the information about the casted fishing hook, even if it is not submerged in a water/lava.
+     * @returns The information about the casted fishing hook.
+     */
+    fun getActiveFishingHook(): ActiveFishingHookInfo? {
+        return activeFishingHook
+    }
+
+    fun getLastActiveFishingHook(): ActiveFishingHookInfo? {
+        return activeFishingHook ?: lastActiveFishingHook
+    }
+
+    fun lastActiveFishingHookSeenAt(): Date? {
+        return activeFishingHookSeenAt
+    }
+
+    /**
+     * Checks if the casted fishing hook (not necessarily submerged) was present during the last given seconds.
+     */
+    fun wasFishingHookActiveSecondsAgo(seconds: Int): Boolean {
+        val lastSeen = activeFishingHookSeenAt ?: return false
+        val now = Date()
+        return now.time - lastSeen.time <= seconds * 1000
+    }
+
+    /**
+     * Check if the player's fishing hook is submerged (into water/lava, or casted into the ground for dirt rod).
      * @returns True if the player's fishing hook is active.
      */
-    fun isFishingHookActive(): Boolean {
+    fun isFishingHookSubmerged(): Boolean {
         return submergedFishingHook != null
     }
 
@@ -52,45 +80,34 @@ object FishingHookUtils {
      * Get the information about the active fishing hook casted into a water/lava.
      * @returns The information about the active fishing hook.
      */
-    fun getActiveFishingHook(): SubmergedFishingHookInfo? {
+    fun getSubmergedFishingHook(): SubmergedFishingHookInfo? {
         return submergedFishingHook
     }
 
-    /**
-     * Get the information about the fishing hook, even if it is not in a water/lava.
-     * @returns The information about the casted fishing hook.
-     */
-    fun getFishingHook(): FishingHookInfo? {
-        return fishingHook
-    }
-
-    fun lastActiveFishingHookSeenAt(): Date? {
+    fun lastSubmergedFishingHookSeenAt(): Date? {
         return submergedFishingHookSeenAt
     }
 
-    fun lastActiveFishingHookInHotspotSeenAt(): Date? {
+    fun lastSubmergedFishingHookInHotspotSeenAt(): Date? {
         return submergedFishingHookInHotspotSeenAt
     }
 
-    fun wasFishingHookActiveMinutesAgo(minutes: Int): Boolean {
-        val lastFishingHookSeenAt = lastActiveFishingHookSeenAt() ?: return false
+    fun wasFishingHookSubmergedMinutesAgo(minutes: Int): Boolean {
+        val lastSeen = lastSubmergedFishingHookSeenAt() ?: return false
         val now = Date()
-
-        return now.time - lastFishingHookSeenAt.time <= minutes * 60 * 1000
+        return now.time - lastSeen.time <= minutes * 60 * 1000
     }
 
-    fun wasFishingHookActiveSecondsAgo(seconds: Int): Boolean {
-        val lastFishingHookSeenAt = lastActiveFishingHookSeenAt() ?: return false
+    fun wasFishingHookSubmergedSecondsAgo(seconds: Int): Boolean {
+        val lastSeen = lastSubmergedFishingHookSeenAt() ?: return false
         val now = Date()
-
-        return now.time - lastFishingHookSeenAt.time <= seconds * 1000
+        return now.time - lastSeen.time <= seconds * 1000
     }
 
-    fun wasFishingHookActiveInHotspotSecondsAgo(seconds: Int): Boolean {
-        val lastFishingHookSeenAt = lastActiveFishingHookInHotspotSeenAt() ?: return false
+    fun wasFishingHookSubmergedInHotspotSecondsAgo(seconds: Int): Boolean {
+        val lastSeen = lastSubmergedFishingHookInHotspotSeenAt() ?: return false
         val now = Date()
-
-        return now.time - lastFishingHookSeenAt.time <= seconds * 1000
+        return now.time - lastSeen.time <= seconds * 1000
     }
 
     private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
@@ -98,28 +115,31 @@ object FishingHookUtils {
             !WorldUtils.isInFishingWorld() ||
             !PlayerUtils.hasFishingRodInHotbar()
         ) {
-            fishingHook = null
+            activeFishingHook = null
+            lastActiveFishingHook = null
             submergedFishingHook = null
             return
         }
 
         val fishingHookEntity = EntityUtils.getPlayersFishingHookEntity() ?: run {
-            fishingHook = null
+            activeFishingHook = null
             submergedFishingHook = null
             return@onClientTick
         }
 
-        fishingHook = FishingHookInfo(
+        activeFishingHook = ActiveFishingHookInfo(
             x = fishingHookEntity.x,
             y = fishingHookEntity.y,
             z = fishingHookEntity.z,
             age = fishingHookEntity.tickCount,
         )
+        lastActiveFishingHook = activeFishingHook
+        activeFishingHookSeenAt = Date()
 
-        if (isOwnFishingHookActive()) {
+        if (isOwnFishingHookSubmerged()) {
             submergedFishingHookSeenAt = Date()
 
-            val closestHotspot = if (WorldUtils.isInHotspotFishingWorld()) HotspotUtils.findClosestHotspotInRange(Vec3(fishingHook!!.x, fishingHook!!.y, fishingHook!!.z), 5.0) else null
+            val closestHotspot = if (WorldUtils.isInHotspotFishingWorld()) HotspotUtils.findClosestHotspotInRange(Vec3(activeFishingHook!!.x, activeFishingHook!!.y, activeFishingHook!!.z), 5.0) else null
             if (closestHotspot != null) submergedFishingHookInHotspotSeenAt = Date()
 
             submergedFishingHook = SubmergedFishingHookInfo(
@@ -135,13 +155,15 @@ object FishingHookUtils {
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
-        fishingHook = null
+        activeFishingHook = null
+        activeFishingHookSeenAt = null
+        lastActiveFishingHook = null
         submergedFishingHook = null
         submergedFishingHookSeenAt = null
         submergedFishingHookInHotspotSeenAt = null
     }
 
-    private fun isOwnFishingHookActive(): Boolean {
+    private fun isOwnFishingHookSubmerged(): Boolean {
         if (!WorldUtils.isInSkyblock()) return false
         val player = FeeshMod.mc.player ?: return false
 


### PR DESCRIPTION
Added option to set delay before players get unhidden for "Hide players near bobber" feature, to avoid players flickering on rod re-cast.