### PR TITLE
fix: Fixed outdated "is fishing rod" item check

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -9,6 +9,7 @@ Released on: ???
 ## Bugfixes
 
 - Fixed slot number that enables Fishing Bag, after SB moved it.
+- Fixed outdated "is fishing rod" item check.
 
 # 1.8.0
 

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -24,7 +24,6 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
 ## Current issues & feedback
 
 - With the release of Minecraft version 26.2 on June 16th, we'll be dropping support for 1.21.9 and 1.21.10. A few weeks after that, we'll drop support for 1.21.11.
-- "Applicable on: Fishing Rod" passes isFishingRod check?
 - Personal blacklist + party sharing
 - Flash drop does not trigger pchat msg?
 - Pickups from trade menu

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
@@ -8,6 +8,7 @@ import net.minecraft.core.component.DataComponents
 import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.item.ItemStack
 import net.minecraft.nbt.NbtOps
+import net.minecraft.world.item.FishingRodItem
 
 object ItemUtils {
     /**
@@ -76,16 +77,17 @@ object ItemUtils {
 
     /*
      * Checks if the item is a Skyblock fishing rod.
-     * @param item The item to check.
+     * @param item The item stack to check.
      * @returns {Boolean} True if the item is a fishing rod, false otherwise.
      */
-    fun isFishingRod(item: ItemStack?): Boolean {
-        if (item == null || item.isEmpty) return false
+    fun isFishingRod(itemStack: ItemStack?): Boolean {
+        if (itemStack == null || itemStack.isEmpty) return false        
+        if (itemStack.item == null || itemStack.item !is FishingRodItem) return false
 
-        val name = item.hoverName.string
+        val name = itemStack.hoverName?.string ?: return false
         if (name.contains("Carnival Rod")) return false
 
-        val loreLines = item.get(DataComponents.LORE)?.lines()?.map { it.string } ?: listOf()
+        val loreLines = itemStack.get(DataComponents.LORE)?.lines()?.map { it.string } ?: listOf()
         return loreLines.any { it.contains("FISHING ROD", ignoreCase = true) || it.contains("FISHING WEAPON", ignoreCase = true) }
     }
 


### PR DESCRIPTION
The check was false-positive for Enchanted Books having "Applicable on: Fishing Rod" in Lore.