### PR TITLE
fix: Made deployables overlay working everywhere in Skyblock if your deployable is placed

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -9,6 +9,7 @@ Released on: ???
 ## Bugfixes
 
 - Fixed slot number that enables Fishing Bag, after SB moved it.
+- Made deployables overlay working everywhere in Skyblock if your deployable is placed.
 - Fixed outdated "is fishing rod" item check.
 
 ## Other

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -25,6 +25,7 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
 
 - With the release of Minecraft version 26.2 on June 16th, we'll be dropping support for 1.21.9 and 1.21.10. A few weeks after that, we'll drop support for 1.21.11.
 - Personal blacklist + party sharing
+- Runic sea creatures - alert or highlight
 - Flash drop does not trigger pchat msg?
 - Pickups from trade menu
 - One click to reset multiple widgets
@@ -35,7 +36,6 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
 - Catches/h for treasures
 - Improve link to changelog in settings, and update announcement
 - Work on various events sounds to make them more unique
-- Deployable in mineshaft
 - 1.21 Fishing Hook armorstand
 - Ragnarok immunity timer
 - Manual "set tracker drops" command does not reset "sc since last" for that drop.

--- a/src/main/kotlin/com/github/sleepypanda/feesh/events/publishers/ArmorStandPublisher.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/events/publishers/ArmorStandPublisher.kt
@@ -27,13 +27,13 @@ object ArmorStandPublisher {
 
     private fun onArmorStandLoaded(event: ArmorStandLoadedEvent) {
         if (!event.entity.isAlive) return
-        if (!WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return
+        if (!WorldUtils.isInSkyblock()) return
 
         loadedThisTick.add(event.entity)
     }
 
     private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
-        if (!WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return
+        if (!WorldUtils.isInSkyblock()) return
         if (queueForNextClientTick.isEmpty() && loadedThisTick.isEmpty()) return
 
         val toProcess = queueForNextClientTick


### PR DESCRIPTION
Fix affects Drarven Lanterns/Umberella not appearing in Mineshafts / other non-fishing locations