### PR TITLE
fix: Fixed various crashes and bugs appearing in lore-related functionalities

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -23,6 +23,15 @@ Released on: ???
 - Refactored way to detect enabled features in slot text / slot background category.
 - Reused code for resetting various overlays.
 
+# 1.8.1
+
+Released on: 2026-06-22
+
+## Bugfixes
+
+- (I hope) fixed various crashes and bugs appearing in lore-related functionalities.
+  - It seems something was done with formatting codes in items' lore on SB side. Please report if more issues arise!
+
 # 1.8.0
 
 Released on: 2026-06-07

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/BaitAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/BaitAlert.kt
@@ -44,7 +44,7 @@ object BaitAlert {
             if (!Alerts.alertOnBaitRunningOut || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld()) return
             if (!FishingHookUtils.wasFishingHookSubmergedMinutesAgo(5)) return
             if (isInFishingBag()) return
-            if (event.baitName.isBlank()) return
+            if (event.baitName.isNullOrBlank()) return
 
             ChatUtils.sendLocalChat("You are almost out of ${event.baitDisplayName}${WHITE}.", true)
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/FishingBagDisabledAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/FishingBagDisabledAlert.kt
@@ -116,7 +116,7 @@ object FishingBagDisabledAlert {
                 val itemName = item.hoverName.string.removeFormatting()
                 if (itemName != USE_BAITS_FROM_BAG_ITEM_NAME) return@timerTask
 
-                val lore = item.get(DataComponents.LORE)?.lines()?.map { it.string } ?: return@timerTask
+                val lore = item.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: return@timerTask
                 val isEnabled = lore.any { line -> line.contains(CLICK_TO_DISABLE_TEXT) }
                 setFishingBagState(isEnabled)
             }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
@@ -7,6 +7,7 @@ import com.github.sleepypanda.feesh.utils.SoundUtils
 import com.github.sleepypanda.feesh.utils.PlayerUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
 import com.github.sleepypanda.feesh.utils.FishingHookUtils
+import com.github.sleepypanda.feesh.utils.ChatUtils.removeFormatting
 import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
@@ -80,7 +81,7 @@ object NonFishingArmorAlert {
         if (item == null || item.isEmpty) return false
 
         val itemName = item.hoverName.string
-        val loreLines = item.get(DataComponents.LORE)?.lines()?.map { it.string } ?: listOf()
+        val loreLines = item.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: listOf()
         
         if (itemName.isEmpty() || loreLines.isEmpty()) return false
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/items/background/KatWrongPetsHighlighter.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/items/background/KatWrongPetsHighlighter.kt
@@ -37,7 +37,7 @@ object KatWrongPetsHighlighter : BaseBackgroundHighlighter() {
             return null
         } else if (slot.index == CONFIRM_SLOT_INDEX) {
             if (itemColorCache.isEmpty()) return null
-            val itemLore = stack.get(DataComponentTypes.LORE)?.lines()?.map { it.getFormattedString() } ?: emptyList()
+            val itemLore = stack.get(DataComponentTypes.LORE)?.lines()?.map { it?.getFormattedString() ?: "" } ?: emptyList()
             if (itemLore.any { it.contains(MEGALODON_ITEM_NAME) }) return highlightColor
             return null
         }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -875,7 +875,7 @@ object FishingProfitTracker : IResettableViewModeTracker {
             }
 
             if (slotItemName.endsWith("Exp Boost")) {
-                val loreLines = stack.get(DataComponents.LORE)?.lines()?.map { it.string } ?: emptyList()
+                val loreLines = stack.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: emptyList()
                 val petItemLine = loreLines.find { it.endsWith("PET ITEM") }
                 if (petItemLine != null) {
                     val description = petItemLine.split(" ").firstOrNull() ?: ""

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/BaitUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/BaitUtils.kt
@@ -57,13 +57,13 @@ object BaitUtils {
         // Fishing bag has preview in slot #9 in hotbar
         // It appears with some delay when holding a fishing rod
         val lastSlotItem = FeeshMod.mc.player?.inventory?.getItem(8) ?: return
-        val currentBaitName = lastSlotItem.hoverName?.string?.removeFormatting() ?: return
+        val currentBaitName = lastSlotItem.hoverName?.string?.removeFormatting()?.takeIf { it.isNotBlank() } ?: return
         if (!currentBaitName.contains("Bait") && !currentBaitName.contains("Obfuscated")) return
 
         val currentBaitDisplayName = lastSlotItem.hoverName.getFormattedString()
-        val lore = lastSlotItem.get(DataComponents.LORE)?.lines()?.map { it.string } ?: return
+        val lore = lastSlotItem.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: return
         val baitRemainingLine = lore.find { it.contains("Bait Remaining:") } ?: return
-        val currentBaitRemaining = baitRemainingLine.split(":")[1].trim().replace(",", "").toInt()
+        val currentBaitRemaining = baitRemainingLine.substringAfter(":").trim().replace(",", "").toIntOrNull() ?: return
         if (currentBaitRemaining <= 0) return
 
         if (currentBaitName == lastBaitName && lastBaitRemaining != null && currentBaitRemaining == lastBaitRemaining!! + 1) return // SB does some kind of "+1 bait refund" when not spending a bait
@@ -76,7 +76,7 @@ object BaitUtils {
         }
 
         if (currentBaitRemaining <= BAIT_RUNNING_OUT_THRESHOLD && shouldPublishBaitRunningOut(currentBaitName)) {
-            EventBus.publish(BaitRunningOutEvent(lastBaitName, lastBaitDisplayName))
+            EventBus.publish(BaitRunningOutEvent(currentBaitName, currentBaitDisplayName))
         }
 
         lastBaitName = currentBaitName

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/CommonUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/CommonUtils.kt
@@ -274,9 +274,9 @@ object CommonUtils {
             block()
         } catch (e: Exception) {
             val shortDetails = e.stackTrace.firstOrNull()?.let { stackTrace ->
-                val file = stackTrace.fileName.ifBlank { "Unknown File" }
+                val file = stackTrace.fileName?.takeIf { it.isNotBlank() } ?: "Unknown File"
                 val line = stackTrace.lineNumber.toString()
-                val method = stackTrace.methodName.ifBlank { "Unknown Method" }
+                val method = stackTrace.methodName?.takeIf { it.isNotBlank() } ?: "Unknown Method"
                 "Error occurred in $file:$line in method $method"
             } ?: ""
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/ItemUtils.kt
@@ -87,7 +87,7 @@ object ItemUtils {
         val name = itemStack.hoverName?.string ?: return false
         if (name.contains("Carnival Rod")) return false
 
-        val loreLines = itemStack.get(DataComponents.LORE)?.lines()?.map { it.string } ?: listOf()
+        val loreLines = itemStack.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: listOf()
         return loreLines.any { it.contains("FISHING ROD", ignoreCase = true) || it.contains("FISHING WEAPON", ignoreCase = true) }
     }
 
@@ -170,7 +170,7 @@ object ItemUtils {
      * @returns {String} The name of the enchanted book, or null if the stack is not an enchanted book.
      */
     fun getEnchantedBookName(stack: ItemStack): String? {
-        val lore = stack.get(DataComponents.LORE)?.lines()?.map { it.string.removeFormatting() } ?: emptyList()
+        val lore = stack.get(DataComponents.LORE)?.lines()?.map { it?.string?.removeFormatting() ?: "" } ?: emptyList()
         val filteredLore = lore.filter { it.isNotBlank() && !it.contains("Combinable in Anvil") }
         val bookName = filteredLore.firstOrNull()?.trim() ?: return null
         if (bookName.isEmpty()) return null


### PR DESCRIPTION
It seems that lore line -> string call now returns text with formatting code, which causes crashing for some users. It was always without formatting before today.

I did not reproduce crashes myself, but noticed the error in logs:

[18:12:13] [Render thread/ERROR]: [Feesh] Error occurred in NumberFormatException.java:67 in method forInputString - Failed to update bait info
java.lang.NumberFormatException: For input string: "§a1345"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:662)
	at java.base/java.lang.Integer.parseInt(Integer.java:778)
	at knot//com.github.sleepypanda.feesh.utils.BaitUtils.updateBaitInfo(BaitUtils.kt:66)
	at knot//com.github.sleepypanda.feesh.utils.BaitUtils.onClientTick(BaitUtils.kt:43)
	at knot//com.github.sleepypanda.feesh.utils.BaitUtils.access$onClientTick(BaitUtils.kt:13)
	at knot//com.github.sleepypanda.feesh.utils.BaitUtils$init$1.invoke(BaitUtils.kt:33)
	at knot//com.github.sleepypanda.feesh.utils.BaitUtils$init$1.invoke(BaitUtils.kt:33)
	at knot//com.github.sleepypanda.feesh.events.EventBus.publish(EventBus.kt:44)
	at knot//com.github.sleepypanda.feesh.events.EventBus.init$lambda$5(EventBus.kt:99)
	at knot//net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.lambda$static$2(ClientTickEvents.java:43)
	at knot//net.minecraft.class_310.handler$zih000$fabric-lifecycle-events-v1$onEndTick(class_310.java:4644)
	at knot//net.minecraft.class_310.method_1574(class_310.java:1999)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1354)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)

Original crash reported by players:
<img width="1247" height="566" alt="image" src="https://github.com/user-attachments/assets/ecd1dcd8-ff20-4c72-9eb4-92725f093edb" />

