### PR TITLE
feat: Added "ALL" option for Rare Drops alert and party message

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -4,15 +4,17 @@ Released on: ???
 
 ## Features
 
+- Added "ALL" option for Rare Drops (alert and party message).
+  - The idea is that you can select ALL once, so all existing and future drops in the list will be always enabled. By default, config library adds new list items as unselected, so you had to manually select new ones.
 - Personal Best adjustments:
   - Added Total Moby-Ducks consumed and Total Blizzards started.
   - Renamed `/feeshPersonalBest` to `/feeshPersonalBests`.
-- Fixed alerts not working for Pyroclasm VI book (SB renamed Magmarizer VI).
 
 ## Bugfixes
 
 - **Fixed rare drop-related functionalities being broken due to Hypixel changing various text symbols (such as Magic Find icon).**
   - For now this update is on Hypixel Alpha, but they might move it to Live server soon, so old Feesh versions will be broken.
+- Fixed alerts not working for Pyroclasm VI book (SB renamed Magmarizer VI).
 - Removed duplicated RARE DROP! chat alert for Singed Powder and Bobbin' Scriptures, as now there is same alert from SB.
 - Fixed text of negative pet level up profit in /feeshPetLevelUpProfit.
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/constants/RareDrops.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/constants/RareDrops.kt
@@ -6,6 +6,8 @@ import com.github.sleepypanda.feesh.utils.enums.FormattingCodes.*
 // Enum used to list selectable items in Alerts/Chat settings
 // This should be aligned with rareDrops.itemName and with itemName published from RareDropsPublisher
 enum class RareDropTypes(val displayName: String) {
+    ALL("ALL"), // Equivalent of selecting all items in the list below
+
     LUCKY_CLOVER_CORE("Lucky Clover Core"),
     DEEP_SEA_ORB("Deep Sea Orb"),
     RADIOACTIVE_VIAL("Radioactive Vial"),

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/RareDropAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/RareDropAlert.kt
@@ -60,9 +60,9 @@ object RareDropAlert {
 
     private fun showAlert(itemName: String, playerName: String, isOwnDrop: Boolean) {
         val dropInfo = RareDrops.rareDrops.find { it.itemName == itemName || it.alternateNames.contains(itemName) } ?: return
-        val type = RareDropTypes.values().find { it.displayName == dropInfo.itemName } ?: return
-
-        if (!Alerts.alertOnRareDropTypes.contains(type)) return
+        val type = RareDropTypes.values().find { it.displayName == dropInfo.itemName } ?: return // Rare drop not supported by the mod
+    
+        if (!Alerts.alertOnRareDropTypes.contains(RareDropTypes.ALL) && !Alerts.alertOnRareDropTypes.contains(type)) return
 
         val showPrice = when (Alerts.rareDropAlertShowPriceFor) {
             RareDropPriceScope.OWN -> isOwnDrop

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareDropMessage.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/chat/RareDropMessage.kt
@@ -37,10 +37,10 @@ object RareDropMessage {
             if (!WorldUtils.isInSkyblock() || !Chat.messageOnRareDrops) return
 
             val dropInfo = RareDrops.rareDrops.find { it.itemName == event.itemName || it.alternateNames.contains(event.itemName) } ?: return
-            val type = RareDropTypes.values().find { it.displayName == dropInfo.itemName } ?: return
+            val type = RareDropTypes.values().find { it.displayName == dropInfo.itemName } ?: return // Rare drop not supported by the mod
     
-            if (!Chat.messageOnRareDropTypes.contains(type)) return
-    
+            if (!Chat.messageOnRareDropTypes.contains(RareDropTypes.ALL) && !Chat.messageOnRareDropTypes.contains(type)) return
+
             var metadata = listOf<String>()
             val dropNumber = getDropNumber(dropInfo.itemName)
             if (dropNumber != null) {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Alerts.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Alerts.kt
@@ -79,8 +79,9 @@ object Alerts : CategoryKt("Alerts") {
         this.description = Translated("Shows a title and plays a sound when a rare item has dropped by you or your party members. Sound can be customized for each item from the list.")
     }
 
-    var alertOnRareDropTypes by select(RareDropTypes.LUCKY_CLOVER_CORE, *RareDropTypes.values()) {
+    var alertOnRareDropTypes by select(RareDropTypes.ALL, *RareDropTypes.values()) {
         this.name = Translated("Select rare drops to be alerted on")
+        this.description = Translated("ALL is equivalent of selecting all items in the list below - you can select it once, to enable all existing and future items in the list.")
         this.searchTerms = RareDropTypes.values().map { it.displayName }.toList()
     }
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Chat.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/Chat.kt
@@ -108,8 +108,9 @@ object Chat : CategoryKt("Chat") {
         this.description = Translated("Sends a PARTY chat message when a rare item has dropped.")
     }
 
-    var messageOnRareDropTypes by select(RareDropTypes.LUCKY_CLOVER_CORE, *RareDropTypes.values()) {
+    var messageOnRareDropTypes by select(RareDropTypes.ALL, *RareDropTypes.values()) {
         this.name = Translated("Select rare drops to share to the PARTY chat")
+        this.description = Translated("ALL is equivalent of selecting all items in the list below - you can select it once, to enable all existing and future items in the list.")
         this.searchTerms = RareDropTypes.values().map { it.displayName }.toList()
     }
 


### PR DESCRIPTION
The idea is that you can select ALL once, so all existing and future drops in the list will be always enabled. By default, config library adds new list items as unselected, so you had to manually select new ones.