### PR TITLE
fix: Fixed "Equip fishing armor" alert showing when Hypixel does not return armor piece name / lore data

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -9,6 +9,7 @@ Released on: ???
 ## Bugfixes
 
 - Fixed Galatea functionalities not working after Hypixel renamed the island to Moonglade Marsh (alpha).
+- Fixed "Equip fishing armor" alert showing when Hypixel does not return armor piece name / NBT data every few seconds.
 - Fixed rare mobs highlight not applying sometimes when the server lags.
 - Fixed Fishing hook timer flickering (not hiding original timer armorstand) sometimes.
 

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -34,7 +34,6 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
  GOOD CATCH! You caught a Shinyfish Shard!
 
 - Equip fishing armor on alpha (???)
-- Galatea -> Moonglade Marsh
 - Mod name is copied as [ Feesh]
 - Do ignore only pets if pet menu is/was opened
 - Issues with setting RNG meter before first dye in Treasure tracker (0 as drops count)

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
@@ -2,7 +2,6 @@ package com.github.sleepypanda.feesh.features.alerts
 
 import com.github.sleepypanda.feesh.FeeshMod
 import com.github.sleepypanda.feesh.settings.categories.Alerts
-import com.github.sleepypanda.feesh.utils.ChatUtils.getUnformattedString
 import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
 import com.github.sleepypanda.feesh.utils.PlayerUtils
@@ -21,7 +20,13 @@ object NonFishingArmorAlert {
     private var lastHookDetectedAt: Date? = null
     private var tickCounter = 0
     private const val TICKS_PER_CHECK = 10
-    private val SPECIAL_ARMOR_ITEM_NAMES = listOf("Hunter", "Squid Hat", "Froggles", "Red Sweater")
+
+    private val FISHING_ARMOR_SET_ID_PREFIXES = listOf(
+        "MAGMA_LORD_", "THUNDER_", "SHARK_SCALE_", "SPONGE_", "ANGLER_", "ABYSSAL_", "DIVER_", "SALMON_", "BACKWATER_",
+        "SLUG_BOOTS", "MOOGMA_LEGGINGS", "FLAMING_CHESTPLATE", "TAURUS_HELMET",
+        "TIKI_MASK", "WATER_HYDRA_HEAD", "FROGGLES", "RED_SWEATER", "SQUID_HAT",
+        "BRONZE_HUNTER_", "SILVER_HUNTER_", "GOLD_HUNTER_", "DIAMOND_HUNTER_",
+    )
     private val FISHING_STATS_LORE_LINES = listOf("Sea Creature Chance:", "Fishing Speed:", "Treasure Chance:", "Trophy Chance:")
 
     fun init() {
@@ -66,29 +71,29 @@ object NonFishingArmorAlert {
 
     private fun isPlayerWearingFishingArmor(): Boolean {
         val player = FeeshMod.mc.player ?: return false
-        
-        val helmet = player.getItemBySlot(EquipmentSlot.HEAD)
-        val chestplate = player.getItemBySlot(EquipmentSlot.CHEST)
-        val leggings = player.getItemBySlot(EquipmentSlot.LEGS)
-        val boots = player.getItemBySlot(EquipmentSlot.FEET)
-        val armorPieces = listOf(helmet, chestplate, leggings, boots)
-        val fishingArmorCount = armorPieces.count { armorPiece -> isFishingArmor(armorPiece) }
+
+        val armorPieces = listOf(
+            player.getItemBySlot(EquipmentSlot.HEAD),
+            player.getItemBySlot(EquipmentSlot.CHEST),
+            player.getItemBySlot(EquipmentSlot.LEGS),
+            player.getItemBySlot(EquipmentSlot.FEET),
+        )
+        val fishingArmorCount = armorPieces.count { isFishingArmor(it) == true }
 
         return fishingArmorCount >= 3 // Helmet may be replaced with something else
     }
 
-    private fun isFishingArmor(item: ItemStack?): Boolean {
+    private fun isFishingArmor(item: ItemStack?): Boolean? {
         if (item == null || item.isEmpty) return false
 
-        val itemName = item.hoverName.getUnformattedString()
-        val loreLines = ItemUtils.getUnformattedLoreLines(item)
-        
-        if (itemName.isEmpty() || loreLines.isEmpty()) return false
+        val itemId = ItemUtils.getCustomData(item)?.let { ItemUtils.getCustomDataId(it) }
+        if (itemId != null && FISHING_ARMOR_SET_ID_PREFIXES.any { itemId.startsWith(it) }) return true
 
-        if (SPECIAL_ARMOR_ITEM_NAMES.any { itemName.contains(it, ignoreCase = true) }) return true
+        val loreLines = ItemUtils.getUnformattedLoreLines(item)
+        if (loreLines.isEmpty()) return null // There was a bug on alpha 01.08.26 when Hypixel does not return any lore every few seconds, and "Leather Chestplate" as item name
 
         return loreLines.any { loreLine ->
-            FISHING_STATS_LORE_LINES.any { loreLine.startsWith(it) }
+            FISHING_STATS_LORE_LINES.any { loreLine.contains(it) }
         }
     }
 }


### PR DESCRIPTION
Issue I observe on Alpha but not on Live yet - every few seconds, Hypixel returns "Leather Chestplate" etc as equipped armor piece name, and no lore NBT data associated, so the alert false triggers