### PR TITLE
fix: Fixed Sprawl and Silkbreeze sea creature catches not being tracked

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.12.1
+
+Released on: 2026-08-04
+
+## Bugfixes
+
+- Fixed Sprawl and Silkbreeze sea creature catches not being tracked (SB changed catch message).
+- 
+
 # 1.12.0
 
 Released on: 2026-08-03

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ dgt.loom.loader.use=false
 # Used for fabric.mod.json
 mod.name=Feesh
 mod.id=feesh
-mod.version=1.12.0-alpha
+mod.version=1.12.1-alpha
 mod.group=com.feesh.mod
 mod.description=QOL fishing mod for Hypixel Skyblock. Introduces a bit of fun for fishing parties :3
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/constants/SeaCreatures.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/constants/SeaCreatures.kt
@@ -237,9 +237,9 @@ object SeaCreatureMessages {
     // TORRHUS CANYON
     const val HAGGARD_MESSAGE = "^A Haggard stumbles to the shore, ready for a fight!$"
     const val BRINELING_MESSAGE = "^A Brineling interrupts you with a stream of bubbles!$"
-    const val SPRAWL_MESSAGE = "^A Sprawl emerges from the blue, and it’s looking for you!$"
+    const val SPRAWL_MESSAGE = "^A Sprawl emerges from the blue, and it's looking for you!$"
     const val TORRID_MESSAGE = "^The laughter of a Torrid echoes through the air\\.$"
-    const val SILKBREEZE_MESSAGE = "^Something zips through the air - it’s a Silkbreeze!$"
+    const val SILKBREEZE_MESSAGE = "^Something zips through the air - it's a Silkbreeze!$"
     const val GIANT_ISOPOD_MESSAGE = "^A Giant Isopod was dredged up from the depths!$"
 }
 


### PR DESCRIPTION
Whopping change to replace ’ in catch message :)