### PR TITLE
fix: Removed Rubber Snorkel from fishing profit tracker pool

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -4,7 +4,7 @@ Released on: ???
 
 ## Bugfixes
 
--
+- Removed Rubber Snorkel from fishing profit tracker pool.
 
 # 1.12.1
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/constants/FishingProfitDrops.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/constants/FishingProfitDrops.kt
@@ -1665,12 +1665,6 @@ class FishingProfitDrops {
                 npcPrice = 800.0,
             ),
             FishingProfitDropInfo(
-                itemId = "RUBBER_SNORKEL",
-                itemName = "Rubber Snorkel",
-                itemDisplayName = "${RARE}Rubber Snorkel",
-                npcPrice = 25_000.0,
-            ),
-            FishingProfitDropInfo(
                 itemId = "HELIXIS",
                 itemName = "Helixis",
                 itemDisplayName = "${RARE}Helixis",


### PR DESCRIPTION
On alpha, it was dropping from some Canyon SC but got deleted