### PR TITLE
fix: Made "Equip fishing armor" alert no longer repeat while the same armor is equipped

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -11,13 +11,15 @@ Released on: ???
 
 ## Bugfixes
 
-- Fixed Magma Pillar highlighting.
+- Fixed partial Magma Pillar highlighting.
 - Fixed "Mute Reindrake gifts" to work when killing other player's dragon.
 - Fixed detection if player is in Trophy armor not working sometimes when SB does not return equipped armor details.
 - Fixed numbers rounding issue showing "1000k" instead of "1M" sometimes.
 - Fixed some cases of items not being counted into the Fishing profit tracker on pickup (e.g. while in pet menu).
 - Pinned Dyes at the top of Fishing profit tracker for NPC Sell price mode.
 - Added Uncommon Foraging Exp Boost (Ent drop) and removed Epic Foraging Exp Boost in the Fishing profit tracker.
+- Made "Equip fishing armor" alert no longer repeat while the same armor is equipped.
+- Made non-reforged Frozen Blaze armor no more triggering "Equip fishing armor" alert.
 
 ## Other
 

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -32,7 +32,9 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
  GOOD CATCH! You caught a Flexbone!
  GOOD CATCH! You caught a Shinyfish Shard!
 
-- Party > [MVP+] Shararame: My Alligator has been cocooned!
+- Hitting own drake sound not muted?
+- lf treasure streak (maybe good, great , outstanding streak but maybe to much)
+- Party > [MVP+] Shararame: My Alligator has been cocooned! My $name has been cocooned!
 - Flipping items via bz + supercraft + sell still gets to the tracker
 - Default party drop on-screen alert ragebaits some people :(
 - Hotspot nametag hider + overlay with hotspot perk

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/alerts/NonFishingArmorAlert.kt
@@ -1,6 +1,5 @@
 package com.github.sleepypanda.feesh.features.alerts
 
-import com.github.sleepypanda.feesh.FeeshMod
 import com.github.sleepypanda.feesh.settings.categories.Alerts
 import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.utils.SoundUtils
@@ -11,23 +10,25 @@ import com.github.sleepypanda.feesh.utils.enums.ColorCodes.*
 import com.github.sleepypanda.feesh.events.EventBus
 import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
-import com.github.sleepypanda.feesh.utils.ItemUtils
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.entity.EquipmentSlot
+import com.github.sleepypanda.feesh.utils.EquippedArmorPiece
 import java.util.Date
 
 object NonFishingArmorAlert {
-    private var lastHookDetectedAt: Date? = null
+    private var lastAlertAt: Date? = null
+    private var lastArmorFingerprint: List<String>? = null
+    private var hasAlertedForCurrentArmor = false
     private var tickCounter = 0
     private const val TICKS_PER_CHECK = 10
+    private const val ALERT_COOLDOWN_MS = 5_000L
 
     private val FISHING_ARMOR_SET_ID_PREFIXES = listOf(
         "MAGMA_LORD_", "THUNDER_", "SHARK_SCALE_", "SPONGE_", "ANGLER_", "ABYSSAL_", "DIVER_", "SALMON_", "BACKWATER_",
         "SLUG_BOOTS", "MOOGMA_LEGGINGS", "FLAMING_CHESTPLATE", "TAURUS_HELMET",
         "TIKI_MASK", "WATER_HYDRA_HEAD", "FROGGLES", "RED_SWEATER", "SQUID_HAT",
         "BRONZE_HUNTER_", "SILVER_HUNTER_", "GOLD_HUNTER_", "DIAMOND_HUNTER_",
+        "FROZEN_BLAZE_",
     )
-    private val FISHING_STATS_LORE_LINES = listOf("Sea Creature Chance:", "Fishing Speed:", "Treasure Chance:", "Trophy Chance:")
+    private val FISHING_STATS_LORE_LINES = listOf("Sea Creature Chance:", "Fishing Speed:", "Treasure Chance:", "Trophy Chance:") // Fallback if ID check does not return true
 
     fun init() {
         EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
@@ -35,7 +36,9 @@ object NonFishingArmorAlert {
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
-        lastHookDetectedAt = null
+        lastAlertAt = null
+        lastArmorFingerprint = null
+        hasAlertedForCurrentArmor = false
     }
 
     private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
@@ -51,48 +54,41 @@ object NonFishingArmorAlert {
     private fun checkAndAlertOnNonFishingArmor() {
         CommonUtils.runWithCatching("Failed to check and alert on non-fishing armor") {
             if (!Alerts.alertOnNonFishingArmor || !WorldUtils.isInSkyblock() || !WorldUtils.isInFishingWorld() || !PlayerUtils.hasFishingRodInHotbar()) return
-            if (isPlayerWearingFishingArmor()) return
 
-            if (lastHookDetectedAt != null) {
-                val now = Date()
-                val diffMillis = now.time - lastHookDetectedAt!!.time
-                if (diffMillis < 10_000) return
+            val armorPieces = PlayerUtils.getEquippedArmorPieces() ?: return
+            val fingerprint = armorPieces.map { it.itemId ?: it.itemName.orEmpty() }
+            if (fingerprint != lastArmorFingerprint) {
+                lastArmorFingerprint = fingerprint
+                hasAlertedForCurrentArmor = false
             }
 
-            val isHookActive = FishingHookUtils.isFishingHookSubmerged()
-            if (!isHookActive) return
+            if (!FishingHookUtils.isFishingHookSubmerged()) return
+            if (hasAlertedForCurrentArmor) return
+            if (lastAlertAt != null && Date().time - lastAlertAt!!.time < ALERT_COOLDOWN_MS) return
+            if (isWearing3PiecesOfFishingArmor(armorPieces)) return
 
-            lastHookDetectedAt = Date()
+            lastAlertAt = Date()
+            hasAlertedForCurrentArmor = true
 
             CommonUtils.showTitle("${RED}Equip fishing armor!")
             SoundUtils.playSound()
         }
     }
 
-    private fun isPlayerWearingFishingArmor(): Boolean {
-        val player = FeeshMod.mc.player ?: return false
-
-        val armorPieces = listOf(
-            player.getItemBySlot(EquipmentSlot.HEAD),
-            player.getItemBySlot(EquipmentSlot.CHEST),
-            player.getItemBySlot(EquipmentSlot.LEGS),
-            player.getItemBySlot(EquipmentSlot.FEET),
-        )
+    private fun isWearing3PiecesOfFishingArmor(armorPieces: Array<EquippedArmorPiece>): Boolean {
         val fishingArmorCount = armorPieces.count { isFishingArmor(it) == true }
-
         return fishingArmorCount >= 3 // Helmet may be replaced with something else
     }
 
-    private fun isFishingArmor(item: ItemStack?): Boolean? {
-        if (item == null || item.isEmpty) return false
+    private fun isFishingArmor(piece: EquippedArmorPiece): Boolean? {
+        if (piece.itemId == null && piece.itemName == null) return false
 
-        val itemId = ItemUtils.getCustomData(item)?.let { ItemUtils.getCustomDataId(it) }
+        val itemId = piece.itemId
         if (itemId != null && FISHING_ARMOR_SET_ID_PREFIXES.any { itemId.startsWith(it) }) return true
 
-        val loreLines = ItemUtils.getUnformattedLoreLines(item)
-        if (loreLines.isEmpty()) return null // There was a bug on alpha 01.08.26 when Hypixel does not return any lore every few seconds, and "Leather Chestplate" as item name
+        if (piece.loreLines.isEmpty()) return null // There was a bug on 01.08.26 when Hypixel does not return any lore every few seconds, and "Leather Chestplate" as item name
 
-        return loreLines.any { loreLine ->
+        return piece.loreLines.any { loreLine ->
             FISHING_STATS_LORE_LINES.any { loreLine.contains(it) }
         }
     }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/PlayerUtils.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/PlayerUtils.kt
@@ -5,9 +5,8 @@ import com.github.sleepypanda.feesh.utils.ChatUtils.getFormattedString
 import com.github.sleepypanda.feesh.utils.ChatUtils.getUnformattedString
 import com.github.sleepypanda.feesh.utils.ItemUtils
 import com.github.sleepypanda.feesh.events.EventBus
+import com.github.sleepypanda.feesh.events.models.ClientTickEvent
 import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
-import java.util.Timer
-import kotlin.concurrent.timerTask
 import net.minecraft.world.entity.EquipmentSlot
 
 data class FishingRodInHandCache(
@@ -18,15 +17,21 @@ data class FishingRodInHandCache(
 data class EquippedArmorPiece(
     val itemId: String? = null,
     val itemName: String? = null,
+    val loreLines: List<String> = emptyList(),
 )
 
 object PlayerUtils {
     private var cachedHasFishingRodInHotbar: Boolean = false
     private var fishingRodInHandCache = null as FishingRodInHandCache?
     private var cachedHasDirtRodInHand: Boolean = false
+
+    private var cachedEquippedArmorPieces: Array<EquippedArmorPiece>? = null
     private var cachedIsInTrophyArmor: Boolean = false
     private var cachedIsInFrozenBlaze: Boolean = false
-    private var timer: Timer? = null
+
+    private var tickCounter = 0
+
+    private const val TICKS_PER_UPDATE = 5
 
     private val TROPHY_ARMOR_ID_PREFIXES = listOf(
         "FROGGLES", "RED_SWEATER",
@@ -38,32 +43,32 @@ object PlayerUtils {
     )
 
     fun init() {
-        startTimer()
+        EventBus.subscribe(ClientTickEvent::class, ::onClientTick)
         EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
     }
 
-    private fun startTimer() {
-        timer?.cancel()
-        timer = Timer("Feesh-PlayerUtils", true)
-        
-        val task = timerTask {
-            CommonUtils.runWithCatching("Failed to update player utils cache") {
-                setHasFishingRodInHotbar()
-                setFishingRodInHand()
-                val armorPieces = getEquippedArmorPieces()
-                setIsInTrophyArmor(armorPieces)
-                setIsInFrozenBlaze(armorPieces)
-            }
+    private fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
+        tickCounter++
+        if (tickCounter < TICKS_PER_UPDATE) return
+        tickCounter = 0
+
+        CommonUtils.runWithCatching("Failed to update player utils cache") {
+            setHasFishingRodInHotbar()
+            setFishingRodInHand()
+            cachedEquippedArmorPieces = readEquippedArmorPieces()
+            setIsInTrophyArmor(cachedEquippedArmorPieces)
+            setIsInFrozenBlaze(cachedEquippedArmorPieces)
         }
-        timer?.scheduleAtFixedRate(task, 0, 250)
     }
 
     private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
         cachedHasFishingRodInHotbar = false
         fishingRodInHandCache = null
         cachedHasDirtRodInHand = false
+        cachedEquippedArmorPieces = null
         cachedIsInTrophyArmor = false
         cachedIsInFrozenBlaze = false
+        tickCounter = 0
     }
 
     /*
@@ -130,7 +135,12 @@ object PlayerUtils {
         return cachedHasDirtRodInHand
     }
 
-    /** Whether the player is wearing the armor for trophy fishing / trophy frogging (Bronze/Silver/Gold/Diamond Hunter, Froggles, Red Sweater). */
+    /** Get the player's equipped armor pieces. */
+    fun getEquippedArmorPieces(): Array<EquippedArmorPiece>? {
+        return cachedEquippedArmorPieces
+    }
+
+    /** Whether the player is wearing the full armor set for trophy fishing / trophy frogging. */
     fun isInTrophyArmor(): Boolean {
         return cachedIsInTrophyArmor
     }
@@ -179,15 +189,16 @@ object PlayerUtils {
         }
     }
 
-    private fun getEquippedArmorPieces(): Array<EquippedArmorPiece>? {
+    private fun readEquippedArmorPieces(): Array<EquippedArmorPiece>? {
         val player = FeeshMod.mc.player ?: return null
-
-        return arrayOf(
+        val armorSlots = arrayOf(
             EquipmentSlot.HEAD,
             EquipmentSlot.CHEST,
             EquipmentSlot.LEGS,
             EquipmentSlot.FEET,
-        ).map { slot ->
+        )
+
+        return armorSlots.map { slot ->
             val armorPiece = player.getItemBySlot(slot)
             if (armorPiece == null || armorPiece.isEmpty) {
                 EquippedArmorPiece()
@@ -195,6 +206,7 @@ object PlayerUtils {
                 EquippedArmorPiece(
                     itemId = ItemUtils.getCustomData(armorPiece)?.let { ItemUtils.getCustomDataId(it) },
                     itemName = armorPiece.hoverName?.getUnformattedString(),
+                    loreLines = ItemUtils.getUnformattedLoreLines(armorPiece),
                 )
             }
         }.toTypedArray()


### PR DESCRIPTION
+ Made non-reforged Frozen Blaze armor no more triggering "Equip fishing armor" alert.