### PR TITLE
fix: Fixed "Mute Reindrake gifts" not working when killing other player's dragon

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -13,7 +13,6 @@ Released on: ???
 ## Bugfixes
 
 - Fixed partial Magma Pillar highlighting.
-- Fixed "Mute Reindrake gifts" to work when killing other player's dragon.
 - Fixed detection if player is in Trophy armor not working sometimes when SB does not return equipped armor details.
 - Fixed numbers rounding issue showing "1000k" instead of "1M" sometimes.
 - Fixed some cases of items not being counted into the Fishing profit tracker on pickup (e.g. while in pet menu).
@@ -21,6 +20,8 @@ Released on: ???
 - Added Uncommon Foraging Exp Boost (Ent drop) and removed Epic Foraging Exp Boost in the Fishing profit tracker.
 - Made "Equip fishing armor" alert no longer repeat while the same armor is equipped.
 - Made non-reforged Frozen Blaze armor no more triggering "Equip fishing armor" alert.
+- Fixed "Mute Reindrake gifts" not working when killing other player's dragon.
+  - There is still issue with Sound Controller overriding mute applied by Feesh.
 
 ## Other
 

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -32,7 +32,7 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
  GOOD CATCH! You caught a Flexbone!
  GOOD CATCH! You caught a Shinyfish Shard!
 
-- Hitting own drake sound not muted?
+- Drake sound not muted when using Sound Controller mod
 - lf treasure streak (maybe good, great , outstanding streak but maybe to much)
 - Party > [MVP+] Shararame: My Alligator has been cocooned! My $name has been cocooned!
 - Flipping items via bz + supercraft + sell still gets to the tracker

--- a/src/main/java/com/github/sleepypanda/feesh/mixin/SoundEngineMixin.java
+++ b/src/main/java/com/github/sleepypanda/feesh/mixin/SoundEngineMixin.java
@@ -40,6 +40,10 @@ public class SoundEngineMixin {
     }
 
     private boolean shouldCancel(SoundInstance sound) {
-        return MuteJadeDragonSound.shouldCancel(sound.getIdentifier()) || MuteReindrakeGifts.shouldCancel(sound.getIdentifier());
+        float volume = sound instanceof AbstractSoundInstance
+                ? ((AbstractSoundInstanceAccessor) sound).feesh$getRawVolume()
+                : 1.0f;
+        return MuteJadeDragonSound.shouldCancel(sound.getIdentifier())
+                || MuteReindrakeGifts.shouldCancel(sound.getIdentifier(), volume);
     }
 }

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/sounds/MuteReindrakeGifts.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/sounds/MuteReindrakeGifts.kt
@@ -10,69 +10,22 @@ import com.github.sleepypanda.feesh.utils.WorldUtils
 import net.minecraft.resources.Identifier
 
 object MuteReindrakeGifts {
-    private const val POST_DEATH_GIFTS_PICKUP_MS = 5_000L // Gifts are still dropping after Reindrake is defeated
-    private val REINDRAKE_DEFEATED_PATTERN = Regex("^DEFEATED! A Reindrake was slain and dropped all its loot!$")
-    private val mutedSoundPaths = setOf<String>("minecraft:item.totem.use")
-
-    private var isReindrakeAlive = false
-    private var remainingReindrakeDeaths = 0
-    private var reindrakeDeadAtMs: Long? = null
+    private val mutedSounds = mapOf(
+        "minecraft:item.totem.use" to 0.5f
+    )
 
     fun init() {
-        EventBus.subscribe(ReindrakeSummonedEvent::class, ::onReindrakeSummoned)
-        EventBus.subscribe(ChatCancellableEvent::class, ::onChat)
-        EventBus.subscribe(WorldChangedEvent::class, ::onWorldChanged)
     }
 
     @JvmStatic
-    fun shouldCancel(soundId: Identifier?): Boolean {
+    fun shouldCancel(soundId: Identifier?, volume: Float): Boolean {
         if (!WorldRendering.muteReindrakeGifts) return false
         if (!isInJerryWorkshop()) return false
-        if (!isReindrakeAlive && !isWithinPostDeathMute()) return false
-        if (soundId == null || soundId.namespace != "minecraft") return false
+        if (soundId == null) return false
 
         val fullSoundPath = "${soundId.namespace}:${soundId.path}"
-        return mutedSoundPaths.contains(fullSoundPath)
-    }
-
-    private fun onChat(event: ChatCancellableEvent) {
-        CommonUtils.runWithCatching("Failed to handle Reindrake death chat") {
-            onReindrakeDeath(event)
-        }
-    }
-
-    private fun onWorldChanged(@Suppress("UNUSED_PARAMETER") event: WorldChangedEvent) {
-        reindrakeDeadAtMs = null
-        isReindrakeAlive = false
-        remainingReindrakeDeaths = 0
-    }
-
-    private fun onReindrakeSummoned(event: ReindrakeSummonedEvent) {
-        if (!isInJerryWorkshop()) return
-        isReindrakeAlive = true
-        remainingReindrakeDeaths = if (event.isDoubleHook) 2 else 1
-        reindrakeDeadAtMs = null
-    }
-
-    private fun onReindrakeDeath(event: ChatCancellableEvent) {
-        if (!isReindrakeAlive || !isInJerryWorkshop()) return
-        if (!REINDRAKE_DEFEATED_PATTERN.matches(event.unformattedText)) return
-
-        reindrakeDeadAtMs = System.currentTimeMillis()
-
-        if (remainingReindrakeDeaths > 0) {
-            remainingReindrakeDeaths--
-        }
-
-        if (remainingReindrakeDeaths <= 0) {
-            isReindrakeAlive = false
-            remainingReindrakeDeaths = 0
-        }
-    }
-
-    private fun isWithinPostDeathMute(): Boolean {
-        val deadAt = reindrakeDeadAtMs ?: return false
-        return System.currentTimeMillis() - deadAt <= POST_DEATH_GIFTS_PICKUP_MS
+        val expectedVolume = mutedSounds[fullSoundPath] ?: return false
+        return volume == expectedVolume
     }
 
     private fun isInJerryWorkshop(): Boolean {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/sounds/MuteReindrakeGifts.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/sounds/MuteReindrakeGifts.kt
@@ -1,11 +1,6 @@
 package com.github.sleepypanda.feesh.features.sounds
 
-import com.github.sleepypanda.feesh.events.EventBus
-import com.github.sleepypanda.feesh.events.models.ChatCancellableEvent
-import com.github.sleepypanda.feesh.events.models.ReindrakeSummonedEvent
-import com.github.sleepypanda.feesh.events.models.WorldChangedEvent
 import com.github.sleepypanda.feesh.settings.categories.WorldRendering
-import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.utils.WorldUtils
 import net.minecraft.resources.Identifier
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/WorldRendering.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/settings/categories/WorldRendering.kt
@@ -97,11 +97,11 @@ object WorldRendering : CategoryKt("World Rendering") {
 
     var muteJadeDragon by boolean(false) {
         this.name = Translated("Mute Jade Dragon")
-        this.description = Translated("Mutes Jade dragon sounds while you are in dragon's cave.")
+        this.description = Translated("Mutes Jade dragon sounds 'entity.ender_dragon.*' while you are in dragon's cave. ${YELLOW}If you use Sound Controller mod, this setting might be overridden by it!")
     }
 
     var muteReindrakeGifts by boolean(false) {
         this.name = Translated("Mute Reindrake gifts")
-        this.description = Translated("Mutes loud 'totem used' sounds while picking up gifts from a Reindrake.")
+        this.description = Translated("Mutes loud 'item.totem.use' sounds while picking up gifts from a Reindrake. ${YELLOW}If you use Sound Controller mod, this setting might be overridden by it!")
     }
 }


### PR DESCRIPTION
The case when you join a lobby and shoot a dragon already existing