### PR TITLE
fix: Fixed Tadgang's tadpoles nametags not being hidden after changing their mob level

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -6,8 +6,12 @@ Released on: ???
 
 - Renamed **/feeshSpiderDenRainSchedule** to **/feeshWeatherSchedule** and changed its output to show upcoming Mild / Extreme weather conditions schedule.
 - Removed old Rain timer overlay/alert and added new Weather timer/alert working for all new weather-affected worlds. **Please re-enable in settings if you need it!**
+
+## Bugfixes
+
 - Removed Corruption I book from profit tracker as they are not in the drop pool anymore.
 - Removed Bayou Travel Scroll from /feeshJunkerJoelShopPrices command output.
+- Fixed Tadgang's tadpoles nametags not being hidden after changing their mob level.
 
 # 1.13.0
 

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HideTadgangNametags.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/rendering/HideTadgangNametags.kt
@@ -33,8 +33,9 @@ object HideTadgangNametags {
 
         CommonUtils.runWithCatching("Failed to check Tadgang nametag") {
             val name = event.customName.unformatted
-            // Tadpoles are level 8, frogs are level 10
-            if (!(name.contains("[Lv8]") && name.contains(SeaCreatureNames.TADGANG))) return
+            // Tadpoles are level 8 pre-update, level 1 post-update, frogs are level 10 or 29
+            if (!name.contains(SeaCreatureNames.TADGANG)) return
+            if (!name.contains("[Lv8]") && !name.contains("[Lv1]")) return // TODO Cleanup old level prefixes
             hiddenNametagIds.add(event.entityId)
         }
     }


### PR DESCRIPTION
Mob level changed from Lvl 8 to Lvl 1 as per https://hypixel.net/threads/august-25th-0-27-1-release-candidate.6144943/#-%E2%9E%A5-fishing