### PR TITLE
fix: Do not show "0s" from Tab list for the Weather event

### DIFF
--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WeatherTimer.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/WeatherTimer.kt
@@ -31,6 +31,8 @@ import java.util.Date
 // Thunder: in 38m
 // Thunder: in 2m 30s
 // Thunder: 2m 30s left
+// Blizzard: 10m 50s
+// Blizzard: 0s
 // Park: same format as new
 
 object WeatherTimer {
@@ -173,7 +175,7 @@ object WeatherTimer {
     private fun updateGuiLines() {
         gui.clearLines()
 
-        if (!Overlays.weatherTimerOverlay || weatherTimerStr.isNullOrEmpty() || weatherSecondsLeft == null) return
+        if (!Overlays.weatherTimerOverlay || weatherTimerStr.isNullOrEmpty() || weatherSecondsLeft == null || weatherSecondsLeft!! <= 0) return
         if (!WorldUtils.isInSkyblock() || !WorldUtils.isInWeatherWorld()) return
 
         val label = eventName ?: "Weather event"


### PR DESCRIPTION
Tab list shows 0s for Blizzard when it's ended, do not show "0s" in the overlay