### PR TITLE
refactor: Removed old Treasure RNG meter migration code

### DIFF
--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/TreasureFishingTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/TreasureFishingTracker.kt
@@ -103,15 +103,6 @@ object TreasureFishingTracker : IResettableViewModeTracker {
         EventBus.subscribe(RareDropEvent::class, ::onRareDrop)
         EventBus.subscribe(GameClosedEvent::class, ::onGameClosed)
     }
-    
-    // TODO: Remove migration code in a while
-    fun migrateCatchesSinceLastDye() {
-        CommonUtils.runWithCatching("Failed to migrate good/great/outstanding catches since last Treasure Dye") {
-            val treasureFishing = PersistentDataManager.feeshData.treasureFishing
-            treasureFishing.total.treasureDyes.catchesBreakdown = getCatchesSinceLastDyeFromTracker(treasureFishing)
-            saveData()
-        }
-    }
 
     override fun getCurrentViewMode(): TrackerViewMode {
         return try {
@@ -141,23 +132,6 @@ object TreasureFishingTracker : IResettableViewModeTracker {
 
     override fun refreshGui() {
         updateGuiLines()
-    }
-
-    private fun getCatchesSinceLastDyeFromTracker(treasureFishing: TreasureFishingData): TreasureCatchesData {
-        val catchesSinceLast = treasureFishing.total.treasureDyes.catchesSinceLast
-        return when (catchesSinceLast) {
-            treasureFishing.total.catches.totalCatches() -> TreasureCatchesData(
-                good = treasureFishing.total.catches.good,
-                great = treasureFishing.total.catches.great,
-                outstanding = treasureFishing.total.catches.outstanding
-            )
-            treasureFishing.session.catches.totalCatches() -> TreasureCatchesData(
-                good = treasureFishing.session.catches.good,
-                great = treasureFishing.session.catches.great,
-                outstanding = treasureFishing.session.catches.outstanding
-            )
-            else -> TreasureCatchesData(good = catchesSinceLast, great = 0, outstanding = 0)
-        }
     }
 
     private fun registerCommands() {

--- a/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/PersistentDataManager.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/utils/data/PersistentDataManager.kt
@@ -7,10 +7,8 @@ import com.github.sleepypanda.feesh.utils.CommonUtils
 import com.github.sleepypanda.feesh.utils.FileUtils
 import com.github.sleepypanda.feesh.utils.gui.FeeshGui
 import com.github.sleepypanda.feesh.utils.enums.Alignment
-import com.github.sleepypanda.feesh.features.overlays.TreasureFishingTracker
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
 import net.fabricmc.loader.api.FabricLoader
 import java.io.File
@@ -161,29 +159,8 @@ object PersistentDataManager {
         val type = object : TypeToken<FeeshData>() {}.type
         val loaded: FeeshData? = FileUtils.loadJsonFromFile(feeshDataFile, type, gson, "Feesh data")
         feeshData = loaded ?: FeeshData()
-        if (loaded != null) { // TODO: Remove migration code
-            val feeshDataFileContent = feeshDataFile.readText()
-            if (jsonHasNestedKey(feeshDataFileContent, "treasureFishing") &&
-                !jsonHasNestedKey(feeshDataFileContent, "treasureFishing", "total", "treasureDyes", "catchesBreakdown")) {
-                TreasureFishingTracker.migrateCatchesSinceLastDye()
-                FeeshMod.LOGGER.info("[Feesh] Successfully migrated catches since last Treasure Dye")
-            }
-        }
         if (loaded != null) {
             FeeshMod.LOGGER.info("[Feesh] Successfully loaded Feesh data entries")
-        }
-    }
-
-    private fun jsonHasNestedKey(content: String, vararg path: String): Boolean {
-        return try {
-            var obj = JsonParser.parseString(content).asJsonObject
-            for (i in 0 until path.size - 1) {
-                if (!obj.has(path[i]) || !obj.get(path[i]).isJsonObject) return false
-                obj = obj.getAsJsonObject(path[i])
-            }
-            obj.has(path.last())
-        } catch (_: Exception) {
-            false
         }
     }
 


### PR DESCRIPTION
Old migration executed a few releases ago when Treasure Dye RNG meter was added.

Players will be able to set Treasure counters via using commands following the guide.