### PR TITLE
feat: Added command to search item data in Fishing profit tracker

### DIFF
--- a/docs/Editing profit tracker.md
+++ b/docs/Editing profit tracker.md
@@ -3,6 +3,7 @@
 ## Table of contents
 
 - [Intro](#intro)
+- [Getting tracker items](#getting-tracker-items)
 - [Editing tracker items](#editing-tracker-items)
 - [Editing elapsed time](#editing-elapsed-time)
 
@@ -11,6 +12,31 @@
 The **Fishing profit tracker** has two view modes: **[Session]** (resets on game close by default, unless disabled) and **[Total]** (persists until you reset it manually). This guide explains how to add, change, or remove items in each mode.
 
 It can be used if some item was not tracked during fishing, or you want to initialize your past drops history in Feesh.
+
+## Getting tracker items
+
+Cheap items and items beyond **Maximum lines count** are grouped under **Other items** on the overlay. Use the command to print item data to your chat, including hidden items. Matching items are listed in chat.
+
+| Action | [Session] | [Total] |
+|--------|-----------|---------|
+| Get item data | `/feeshGetItemFishingProfitTracker <ITEM_ID or ITEM_NAME>` | `/feeshGetItemFishingProfitTrackerTotal <ITEM_ID or ITEM_NAME>` |
+
+Query must be at least **3** characters.
+
+- `ITEM_ID` - exact match. Look at [Item IDs](#item-ids) below.
+- `ITEM_NAME` - full or partial item name.
+
+Examples:
+
+```text
+/feeshGetItemFishingProfitTracker ENCHANTED_SPONGE
+/feeshGetItemFishingProfitTracker Sponge
+/feeshGetItemFishingProfitTracker Fished Coins
+/feeshGetItemFishingProfitTrackerTotal Silver Magmafish
+/feeshGetItemFishingProfitTrackerTotal MAGMA_FISH_SILVER
+/feeshGetItemFishingProfitTrackerTotal Baby Yeti
+/feeshGetItemFishingProfitTrackerTotal FLYING_FISH;4+100
+```
 
 ## Editing tracker items
 
@@ -38,8 +64,8 @@ You can use chat commands when you need to set or adjust count for the items. Ma
 
 | Action | [Session] | [Total] |
 |--------|-----------|---------|
-| Set / adjust item count | `/feeshSetItemCountFishingProfit <ITEM_ID> <COUNT>` | `/feeshSetItemCountFishingProfitTotal <ITEM_ID> <COUNT>` |
-| Delete item (with confirmation) | `/feeshDeleteItemFishingProfit <ITEM_ID>` | `/feeshDeleteItemFishingProfitTotal <ITEM_ID>` |
+| Set / adjust item count | `/feeshSetItemCountFishingProfitTracker <ITEM_ID> <COUNT>` | `/feeshSetItemCountFishingProfitTrackerTotal <ITEM_ID> <COUNT>` |
+| Delete item (with confirmation) | `/feeshDeleteItemFishingProfitTracker <ITEM_ID>` | `/feeshDeleteItemFishingProfitTrackerTotal <ITEM_ID>` |
 
 **`<COUNT>` formats**
 
@@ -54,12 +80,12 @@ You can use chat commands when you need to set or adjust count for the items. Ma
 ### Examples
 
 ```text
-/feeshSetItemCountFishingProfit RADIOACTIVE_VIAL +1
-/feeshSetItemCountFishingProfit MAGMA_FISH 64000
-/feeshSetItemCountFishingProfitTotal MAGMA_FISH_SILVER 10000
-/feeshSetItemCountFishingProfit FLYING_FISH;4+100 3
-/feeshSetItemCountFishingProfit ENCHANTED_SPONGE -10
-/feeshDeleteItemFishingProfit ENCHANTED_SPONGE
+/feeshSetItemCountFishingProfitTracker RADIOACTIVE_VIAL +1
+/feeshSetItemCountFishingProfitTracker MAGMA_FISH 64000
+/feeshSetItemCountFishingProfitTrackerTotal MAGMA_FISH_SILVER 10000
+/feeshSetItemCountFishingProfitTracker FLYING_FISH;4+100 3
+/feeshSetItemCountFishingProfitTracker ENCHANTED_SPONGE -10
+/feeshDeleteItemFishingProfitTracker ENCHANTED_SPONGE
 ```
 
 ### Item IDs
@@ -97,7 +123,7 @@ While the overlay is **visible**, you can use the following commands:
 
 | Action | [Session] | [Total] |
 |--------|-----------|---------|
-| Set / adjust time | `/feeshSetTimeFishingProfit <SECONDS>` | `/feeshSetTimeFishingProfitTotal <SECONDS>` |
+| Set / adjust time | `/feeshSetTimeFishingProfitTracker <SECONDS>` | `/feeshSetTimeFishingProfitTrackerTotal <SECONDS>` |
 
 **`<SECONDS>` formats**
 
@@ -112,9 +138,9 @@ Result must be more than or equal to 0. Invalid input shows an error in chat.
 Examples:
 
 ```text
-/feeshSetTimeFishingProfit 3600
-/feeshSetTimeFishingProfitTotal +7200
-/feeshSetTimeFishingProfit -300
+/feeshSetTimeFishingProfitTracker 3600
+/feeshSetTimeFishingProfitTrackerTotal +7200
+/feeshSetTimeFishingProfitTracker -300
 ```
 
 If you don't know elapsed time for [Total], you might use **Hide timer and coins/h in [Total]** to show only the items list.

--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -5,6 +5,7 @@ Released on: ???
 ## Features
 
 - Added option to track & show costs (spent bait, shurikens) in Fishing profit tracker. This also shows net profit after subtracting costs from total profit. You can disable it in settings.
+  - Not shown when NPC Price mode selected.
 - Improved settings search:
   - You can search for version-specific features in /feesh settings GUI (e.g. search for 1.14.0 to see new settings added in this version).
   - You can provide search query when calling /feesh command: `/feesh 1.14.0` or `/feesh profit tracker`.
@@ -14,10 +15,16 @@ Released on: ???
   - Removed "Blizzards started" counter from Personal Bests, because Blizzard in a Bottle will become a mixin after the update.
 - Added alert when a fishing drop (e.g. raw fish) overflows into your inventory, meaning sack is full [disabled by default]. It offers buttons for Supercrafting a compacted item / Bazaar sell.
 - Added "Alert when Day/Night started" when Skyblock time hits 6:00am or 7:00pm [disabled by default]. Can be useful for swapping Light/Dark baits or other activities.
-- Adjustments to editing Treasure fishing tracker data:
-  - Allowed 0 as Treasure Dye drop count in `/feeshSetTrackerDrops` command, to initialize catches before your first Treasure Dye.
-  - Added `/feeshSetTreasureCatches` / `/feeshSetTreasureCatchesTotal` to set Good/Great/Outstanding catches counts for Session and Total mode.
-  - Added [Editing treasure fishing tracker guide](https://github.com/Sleepy-Panda/Feesh/blob/develop/docs/Editing%20treasure%20fishing%20tracker.md).
+- Trackers commands adjustments:
+  - Added command to search item data in Fishing profit tracker:
+    - `/feeshGetItemFishingProfitTracker` / `/feeshGetItemFishingProfitTrackerTotal`
+    - Pass item ID or full/partial item name as argument
+    - [Guide](https://github.com/Sleepy-Panda/Feesh/blob/develop/docs/Editing%20profit%20tracker.md#getting-tracker-items)
+  - Renamed some commands to edit Fishing profit tracker, to follow consistent naming style.
+  - Adjustments to editing Treasure fishing tracker data:
+    - Allowed 0 as Treasure Dye drop count in `/feeshSetTrackerDrops` command, to initialize catches before your first Treasure Dye.
+    - Added `/feeshSetTreasureCatches` / `/feeshSetTreasureCatchesTotal` to set Good/Great/Outstanding catches counts for Session and Total mode.
+    - Added [Editing treasure fishing tracker guide](https://github.com/Sleepy-Panda/Feesh/blob/develop/docs/Editing%20treasure%20fishing%20tracker.md).
 
 ## Bugfixes
 

--- a/docs/dev/TODOs.md
+++ b/docs/dev/TODOs.md
@@ -33,6 +33,7 @@ Newly released - https://hypixel.net/threads/hypixel-skyblock-0-24-5-assorted-qo
  GOOD CATCH! You caught a Shinyfish Shard!
 
 - You cannot send same message twice when sharing Isopods
+- For level 100 pets, would be cool to change their item name to be aligned with Level 1 pets. This also causes Lvl 100 pets being not easily found ny name via /get command.
 - Drake sound not muted when using Sound Controller mod
 - integrate medal clipping for rare drops / dyes? have seen it in sbo and its pretty neat  https://medal.tv/developer/auto-clipping#api-reference
 - lf treasure streak (maybe good, great , outstanding streak but maybe to much)

--- a/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
+++ b/src/main/kotlin/com/github/sleepypanda/feesh/features/overlays/FishingProfitTracker.kt
@@ -89,14 +89,16 @@ object FishingProfitTracker : IResettableViewModeTracker {
     const val PAUSE_COMMAND = "feeshPauseFishingProfitTracker"
 
     const val TOGGLE_VIEW_MODE_COMMAND = "feeshToggleFishingProfitTrackerViewMode"
-    const val SET_ITEM_COUNT_COMMAND = "feeshSetItemCountFishingProfit"
-    const val SET_ITEM_COUNT_TOTAL_COMMAND = "feeshSetItemCountFishingProfitTotal"
-    const val DELETE_ITEM_COMMAND = "feeshDeleteItemFishingProfit"
-    const val DELETE_ITEM_TOTAL_COMMAND = "feeshDeleteItemFishingProfitTotal"
-    const val SET_TIME_COMMAND = "feeshSetTimeFishingProfit"
-    const val SET_TIME_TOTAL_COMMAND = "feeshSetTimeFishingProfitTotal"
-    const val RESET_COSTS_COMMAND = "feeshResetFishingProfitTrackerCosts"
-    const val RESET_COSTS_TOTAL_COMMAND = "feeshResetFishingProfitTrackerCostsTotal"
+    const val SET_ITEM_COUNT_COMMAND = "feeshSetItemCountFishingProfitTracker"
+    const val SET_ITEM_COUNT_TOTAL_COMMAND = "feeshSetItemCountFishingProfitTrackerTotal"
+    const val GET_ITEM_COMMAND = "feeshGetItemFishingProfitTracker"
+    const val GET_ITEM_TOTAL_COMMAND = "feeshGetItemFishingProfitTrackerTotal"
+    const val DELETE_ITEM_COMMAND = "feeshDeleteItemFishingProfitTracker"
+    const val DELETE_ITEM_TOTAL_COMMAND = "feeshDeleteItemFishingProfitTrackerTotal"
+    const val SET_TIME_COMMAND = "feeshSetTimeFishingProfitTracker"
+    const val SET_TIME_TOTAL_COMMAND = "feeshSetTimeFishingProfitTrackerTotal"
+    const val RESET_COSTS_COMMAND = "feeshResetCostsFishingProfitTracker"
+    const val RESET_COSTS_TOTAL_COMMAND = "feeshResetCostsFishingProfitTrackerTotal"
 
     private val COINS_CATCH_PATTERN = Regex("^. (?:GOOD|GREAT|OUTSTANDING) CATCH! You caught ([\\d,]+) Coins.*")
     private val ICE_ESSENCE_CATCH_PATTERN = Regex("^. (?:GOOD|GREAT|OUTSTANDING) CATCH! You caught Ice Essence x([\\d,]+).*")
@@ -207,6 +209,12 @@ object FishingProfitTracker : IResettableViewModeTracker {
         }
         RegisterUtils.command(SET_ITEM_COUNT_TOTAL_COMMAND) { args ->
             onSetItemCountCommand(args, TrackerViewMode.TOTAL)
+        }
+        RegisterUtils.command(GET_ITEM_COMMAND) { args ->
+            onGetItemCommand(args, TrackerViewMode.SESSION)
+        }
+        RegisterUtils.command(GET_ITEM_TOTAL_COMMAND) { args ->
+            onGetItemCommand(args, TrackerViewMode.TOTAL)
         }
         RegisterUtils.command(DELETE_ITEM_COMMAND) { args ->
             onDeleteItemCommand(args, TrackerViewMode.SESSION)
@@ -405,6 +413,68 @@ object FishingProfitTracker : IResettableViewModeTracker {
 
             val viewModeText = getViewModeDisplayText(viewMode)
             ChatUtils.sendLocalChat("${WHITE}Count of ${displayName} ${WHITE}in Fishing profit tracker $viewModeText ${WHITE}is changed from ${AQUA}${previousCount} ${WHITE}to ${AQUA}${count}${WHITE}.", true)
+        }
+    }
+
+    private fun onGetItemCommand(args: Array<String>, viewMode: TrackerViewMode) {
+
+        fun findProfitTrackerItemsByIdOrName(sourceObj: FishingProfitSourceData, query: String): List<ProfitTrackerItemEntry> {
+            val matches = mutableMapOf<String, ProfitTrackerItemEntry>()
+            sourceObj.profitTrackerItems[query]?.let { matches[it.itemId] = it }
+            sourceObj.profitTrackerItems.values
+                .filter { it.itemName.contains(query, ignoreCase = true) }
+                .forEach { matches[it.itemId] = it }
+            return matches.values.sortedByDescending { it.totalItemProfit }
+        }
+
+        fun formatMatchLine(entry: ProfitTrackerItemEntry): String {
+            val displayName = getDisplayNameForGui(entry.itemId, entry.itemName)
+            val countStr = CommonUtils.formatNumberWithSpaces(entry.amount)
+            val profitStr = CommonUtils.toShortNumber(entry.totalItemProfit) ?: "0"
+            return "${GRAY}- ${WHITE}${countStr}${GRAY}x ${displayName}${WHITE}: ${GOLD}${profitStr}${WHITE} coins. Item ID: ${AQUA}${entry.itemId}${WHITE}"
+        }
+
+        CommonUtils.runWithCatching("Failed to get item from Fishing profit tracker") {
+            val commandName = when (viewMode) {
+                TrackerViewMode.SESSION -> GET_ITEM_COMMAND
+                TrackerViewMode.TOTAL -> GET_ITEM_TOTAL_COMMAND
+            }
+            val query = args.joinToString(" ").trim()
+            if (query.isBlank()) {
+                ChatUtils.sendLocalChat(
+                    "${RED}Usage: /$commandName <itemID or itemName>",
+                    true
+                )
+                return
+            }
+            if (query.length < 3) {
+                ChatUtils.sendLocalChat("${RED}Search query must be at least 3 characters.", true)
+                return
+            }
+
+            val viewModeText = getViewModeDisplayText(viewMode)
+            val sourceObj = getSourceObject(viewMode)
+            val matches = findProfitTrackerItemsByIdOrName(sourceObj, query)
+            if (matches.isEmpty()) {
+                ChatUtils.sendLocalChat(
+                    "${RED}Item '${query}' is not found in the Fishing profit tracker $viewModeText${RED}!",
+                    true
+                )
+                return
+            }
+
+            ChatUtils.sendLocalChat(
+                "${WHITE}Matching items in the Fishing profit tracker $viewModeText${WHITE}:",
+                true
+            )
+
+            val maxMatchesToShow = 5
+            matches.take(maxMatchesToShow).forEach { ChatUtils.sendLocalChat(formatMatchLine(it)) }
+            if (matches.size > maxMatchesToShow) {
+                ChatUtils.sendLocalChat(
+                    "${GRAY}Showing top ${maxMatchesToShow} of ${matches.size} matches - refine search parameter to see the relevant results."
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Added command to search item data in Fishing profit tracker:
  - `/feeshGetItemFishingProfitTracker` / `/feeshGetItemFishingProfitTrackerTotal`
  - Pass item ID or full/partial item name as argument
  - [Guide](https://github.com/Sleepy-Panda/Feesh/blob/develop/docs/Editing%20profit%20tracker.md#getting-tracker-items)